### PR TITLE
chore: update URLs in README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![pub package](https://img.shields.io/pub/v/dart_wot.svg)](https://pub.dev/packages/dart_wot)
-[![Build](https://github.com/namib-project/dart_wot/actions/workflows/ci.yml/badge.svg)](https://github.com/namib-project/dart_wot/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/namib-project/dart_wot/branch/main/graph/badge.svg?token=76OBNOVL60)](https://codecov.io/gh/namib-project/dart_wot)
+[![Build](https://github.com/eclipse-thingweb/dart_wot/actions/workflows/ci.yml/badge.svg)](https://github.com/eclipse-thingweb/dart_wot/actions/workflows/ci.yml)
+[![codecov](https://codecov.io/gh/eclipse-thingweb/dart_wot/branch/main/graph/badge.svg?token=76OBNOVL60)](https://codecov.io/gh/eclipse-thingweb/dart_wot)
 [![style: lint](https://img.shields.io/badge/style-lint-4BC0F5.svg)](https://pub.dev/packages/lint)
 
 # dart_wot


### PR DESCRIPTION
Similarly to #69, this PR updates the URLs used in badges within the README file.

For the codecov badge to continue working, we may need to update the secret associated with this repository (see [here](https://app.codecov.io/gh/eclipse-thingweb/dart_wot/new)).  