### PR TITLE
chore: use correct license header for CoAP test files

### DIFF
--- a/test/binding_coap/binding_coap_test.dart
+++ b/test/binding_coap/binding_coap_test.dart
@@ -1,12 +1,8 @@
-// Copyright 2022 Contributors to the Eclipse Foundation
+// Copyright 2022 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 //
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-//
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:dart_wot/dart_wot.dart';
 import 'package:mockito/annotations.dart';

--- a/test/binding_coap/coap_vocabulary_test.dart
+++ b/test/binding_coap/coap_vocabulary_test.dart
@@ -1,12 +1,8 @@
-// Copyright 2023 Contributors to the Eclipse Foundation
+// Copyright 2023 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
 //
-// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
-// https://www.apache.org/licenses/LICENSE-2.0> or the MIT license
-// <LICENSE-MIT or https://opensource.org/licenses/MIT>, at your
-// option. This file may not be copied, modified, or distributed
-// except according to those terms.
-//
-// SPDX-License-Identifier: MIT OR Apache-2.0
+// SPDX-License-Identifier: BSD-3-Clause
 
 import 'package:coap/coap.dart';
 import 'package:dart_wot/dart_wot.dart';


### PR DESCRIPTION
In two test files for CoAP, the wrong license header was being used. This PR updates the headers so that the two files are using the same as all of the other files in the project.