### PR TITLE
feat!: improve TD data model and serialization behavior

### DIFF
--- a/example/coaps_readproperty.dart
+++ b/example/coaps_readproperty.dart
@@ -45,7 +45,7 @@ Future<void> main(List<String> args) async {
   final wot = await servient.start();
 
   const thingDescriptionJson = {
-    "@context": "http://www.w3.org/ns/td",
+    "@context": "https://www.w3.org/2022/wot/td/v1.1",
     "title": "Test Thing",
     "base": "coaps://californium.eclipseprojects.io",
     "security": ["psk_sc"],

--- a/example/coaps_readproperty.dart
+++ b/example/coaps_readproperty.dart
@@ -44,31 +44,24 @@ Future<void> main(List<String> args) async {
 
   final wot = await servient.start();
 
-  const thingDescriptionJson = '''
-  {
+  const thingDescriptionJson = {
     "@context": "http://www.w3.org/ns/td",
     "title": "Test Thing",
     "base": "coaps://californium.eclipseprojects.io",
     "security": ["psk_sc"],
     "securityDefinitions": {
-      "psk_sc": {
-        "scheme": "psk",
-        "identity": "Client_identity"
-      }
+      "psk_sc": {"scheme": "psk", "identity": "Client_identity"},
     },
     "properties": {
       "status": {
         "forms": [
-          {
-            "href": "/test"
-          }
-        ]
-      }
-    }
-  }
-  ''';
+          {"href": "/test"},
+        ],
+      },
+    },
+  };
 
-  final thingDescription = ThingDescription(thingDescriptionJson);
+  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
   final status = await consumedThing.readProperty("status");
   final value = await status.value();

--- a/example/coaps_readproperty.dart
+++ b/example/coaps_readproperty.dart
@@ -61,7 +61,7 @@ Future<void> main(List<String> args) async {
     },
   };
 
-  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
+  final thingDescription = thingDescriptionJson.toThingDescription();
   final consumedThing = await wot.consume(thingDescription);
   final status = await consumedThing.readProperty("status");
   final value = await status.value();

--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -10,7 +10,7 @@ import "package:dart_wot/dart_wot.dart";
 
 const thingDescriptionJson = {
   "@context": [
-    "http://www.w3.org/ns/td",
+    "https://www.w3.org/2022/wot/td/v1.1",
     {"@language": "de", "coap": "http://www.example.org/coap-binding#"},
   ],
   "title": "Test Thing",

--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -8,14 +8,10 @@
 
 import "package:dart_wot/dart_wot.dart";
 
-const thingDescriptionJson = '''
-{
+const thingDescriptionJson = {
   "@context": [
     "http://www.w3.org/ns/td",
-    {
-      "@language": "de",
-      "coap": "http://www.example.org/coap-binding#"
-    }
+    {"@language": "de", "coap": "http://www.example.org/coap-binding#"},
   ],
   "title": "Test Thing",
   "id": "urn:test",
@@ -23,79 +19,59 @@ const thingDescriptionJson = '''
   "securityDefinitions": {
     "nosec_sc": {
       "scheme": "nosec",
-      "descriptions": {
-        "de": "Keine Sicherheit",
-        "en": "No Security"
-      }
+      "descriptions": {"de": "Keine Sicherheit", "en": "No Security"},
     },
-    "basic_sc": {
-      "scheme": "basic",
-      "description": "Test"
-    }
+    "basic_sc": {"scheme": "basic", "description": "Test"},
   },
   "security": "nosec_sc",
   "properties": {
     "status": {
       "observable": true,
       "forms": [
-        {
-          "href": "/.well-known/core"
-        },
+        {"href": "/.well-known/core"},
         {
           "href": "coap://californium.eclipseprojects.io/obs",
-          "op": ["observeproperty", "unobserveproperty"]
+          "op": ["observeproperty", "unobserveproperty"],
         }
-      ]
+      ],
     },
     "differentStatus": {
       "forms": [
-        {
-          "href": "coap://coap.me",
-          "coap:method": "GET"
-        }
-      ]
+        {"href": "coap://coap.me", "coap:method": "GET"},
+      ],
     },
     "anotherStatus": {
-            "uriVariables": {
-              "test": {
-                "type": "string"
-              }
-            },
+      "uriVariables": {
+        "test": {"type": "string"},
+      },
       "forms": [
-        {
-          "href": "coap://coap.me/query{?test}"
-        }
-      ]
+        {"href": "coap://coap.me/query{?test}"},
+      ],
     },
     "test": {
       "forms": [
         {
           "href": "http://example.org",
-          "security": ["basic_sc"]
+          "security": ["basic_sc"],
         }
-      ]
-    }
+      ],
+    },
   },
   "actions": {
     "toggle": {
       "forms": [
-        {
-          "href": "coap://coap.me/large-create"
-        }
-      ]
-    }
+        {"href": "coap://coap.me/large-create"},
+      ],
+    },
   },
   "events": {
     "overheating": {
       "forms": [
-        {
-          "href": "coap://coap.me"
-        }
-      ]
-    }
-  }
-}
-''';
+        {"href": "coap://coap.me"},
+      ],
+    },
+  },
+};
 
 final Map<String, BasicCredentials> basicCredentials = {
   "urn:test": BasicCredentials("username", "password"),
@@ -103,10 +79,10 @@ final Map<String, BasicCredentials> basicCredentials = {
 
 Future<BasicCredentials?> basicCredentialsCallback(
   Uri uri,
-  Form? form, [
+  AugmentedForm? form, [
   BasicCredentials? invalidCredentials,
 ]) async {
-  final id = form?.thingDescription.identifier;
+  final id = form?.tdIdentifier;
 
   return basicCredentials[id];
 }
@@ -127,7 +103,7 @@ Future<void> main() async {
   );
   final wot = await servient.start();
 
-  final thingDescription = ThingDescription(thingDescriptionJson);
+  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
   final status = await consumedThing.readProperty("status");
   final value1 = await status.value();

--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -103,7 +103,7 @@ Future<void> main() async {
   );
   final wot = await servient.start();
 
-  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
+  final thingDescription = thingDescriptionJson.toThingDescription();
   final consumedThing = await wot.consume(thingDescription);
   final status = await consumedThing.readProperty("status");
   final value1 = await status.value();

--- a/example/core_link_format_discovery.dart
+++ b/example/core_link_format_discovery.dart
@@ -8,30 +8,35 @@
 
 import "package:dart_wot/dart_wot.dart";
 
-const propertyName = "status";
-const actionName = "toggle";
-
 Future<void> main(List<String> args) async {
   final servient = Servient(clientFactories: [CoapClientFactory()]);
 
   final wot = await servient.start();
 
-  // TODO(JKRhb): Replace with an endpoint providing CoRE Format Links pointing
-  //              to TDs. At the moment, this URI is just for illustrative
-  //              purpose and will not return actual Thing Description links.
-  final discoveryUri = Uri.parse("coap://coap.me/.well-known/core");
+  final discoveryUri =
+      Uri.parse("coap://plugfest.thingweb.io/.well-known/core");
 
   await for (final thingDescription
       in wot.discover(discoveryUri, method: DiscoveryMethod.coreLinkFormat)) {
+    print(thingDescription.title);
+
+    if (thingDescription.title != "Smart-Coffee-Machine") {
+      continue;
+    }
+
     final consumedThing = await wot.consume(thingDescription);
 
     try {
-      final statusBefore = await consumedThing.readProperty(propertyName);
+      final statusBefore =
+          await consumedThing.readProperty("allAvailableResources");
       print(await statusBefore.value());
 
-      await consumedThing.invokeAction(actionName);
+      final result = await consumedThing.invokeAction("makeDrink");
 
-      final statusAfter = await consumedThing.readProperty(propertyName);
+      print(await result.value());
+
+      final statusAfter =
+          await consumedThing.readProperty("allAvailableResources");
       print(await statusAfter.value());
     } on Exception catch (e) {
       print(e);

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -11,7 +11,7 @@ import "package:dart_wot/dart_wot.dart";
 const username = "username";
 const password = "password";
 const thingDescriptionJson = {
-  "@context": ["http://www.w3.org/ns/td"],
+  "@context": "https://www.w3.org/2022/wot/td/v1.1",
   "title": "Test Thing",
   "id": "urn:test",
   "base": "https://httpbin.org",

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -67,7 +67,7 @@ Future<void> main(List<String> args) async {
   );
   final wot = await servient.start();
 
-  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
+  final thingDescription = thingDescriptionJson.toThingDescription();
   final consumedThing = await wot.consume(thingDescription);
   final status = await consumedThing.readProperty("status");
 

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -10,40 +10,29 @@ import "package:dart_wot/dart_wot.dart";
 
 const username = "username";
 const password = "password";
-const thingDescriptionJson = '''
-      {
-        "@context": ["http://www.w3.org/ns/td"],
-        "title": "Test Thing",
-        "id": "urn:test",
-        "base": "https://httpbin.org",
-        "securityDefinitions": {
-          "auto_sc": {
-            "scheme": "auto"
-          },
-          "basic_sc": {
-            "scheme": "basic"
-          }
-        },
-        "security": "auto_sc",
-        "properties": {
-          "status": {
-            "forms": [
-              {
-                "href": "/basic-auth/$username/$password"
-              }
-            ]
-          },
-          "status2": {
-            "forms": [
-              {
-                "href": "/basic-auth/$username/$password",
-                "security": "basic_sc"
-              }
-            ]
-          }
-        }
-      }
-      ''';
+const thingDescriptionJson = {
+  "@context": ["http://www.w3.org/ns/td"],
+  "title": "Test Thing",
+  "id": "urn:test",
+  "base": "https://httpbin.org",
+  "securityDefinitions": {
+    "auto_sc": {"scheme": "auto"},
+    "basic_sc": {"scheme": "basic"},
+  },
+  "security": "auto_sc",
+  "properties": {
+    "status": {
+      "forms": [
+        {"href": "/basic-auth/$username/$password"},
+      ],
+    },
+    "status2": {
+      "forms": [
+        {"href": "/basic-auth/$username/$password", "security": "basic_sc"},
+      ],
+    },
+  },
+};
 
 final basicCredentials = BasicCredentials("username", "password");
 
@@ -53,14 +42,14 @@ final Map<String, BasicCredentials> basicCredentialsMap = {
 
 Future<BasicCredentials?> basicCredentialsCallback(
   Uri uri,
-  Form? form,
+  AugmentedForm? form,
   BasicCredentials? invalidCredentials,
 ) async {
   if (form == null) {
     return basicCredentials;
   }
 
-  final id = form.thingDescription.identifier;
+  final id = form.tdIdentifier;
 
   return basicCredentialsMap[id];
 }
@@ -78,7 +67,7 @@ Future<void> main(List<String> args) async {
   );
   final wot = await servient.start();
 
-  final thingDescription = ThingDescription(thingDescriptionJson);
+  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
   final status = await consumedThing.readProperty("status");
 

--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -8,47 +8,41 @@
 
 import "package:dart_wot/dart_wot.dart";
 
-const thingDescriptionJson = '''
-  {
-    "@context": "https://www.w3.org/2022/wot/td/v1.1",
-    "title": "Test Thing",
-    "id": "urn:test",
-    "base": "coap://coap.me",
-    "security": ["auto_sc"],
-    "securityDefinitions": {
-      "auto_sc": {
-        "scheme": "auto"
-      }
+const thingDescriptionJson = {
+  "@context": "https://www.w3.org/2022/wot/td/v1.1",
+  "title": "Test Thing",
+  "id": "urn:test",
+  "base": "coap://coap.me",
+  "security": ["auto_sc"],
+  "securityDefinitions": {
+    "auto_sc": {"scheme": "auto"},
+  },
+  "properties": {
+    "status": {
+      "observable": true,
+      "forms": [
+        {
+          "href": "mqtt://test.mosquitto.org:1884",
+          "mqv:filter": "test",
+          "op": ["readproperty", "observeproperty"],
+          "contentType": "text/plain",
+        }
+      ],
     },
-    "properties": {
-      "status": {
-        "observable": true,
-        "forms": [
-          {
-            "href": "mqtt://test.mosquitto.org:1884",
-            "mqv:filter": "test",
-            "op": ["readproperty", "observeproperty"],
-            "contentType": "text/plain"
-          }
-        ]
-      }
+  },
+  "actions": {
+    "toggle": {
+      "input": {"type": "string"},
+      "forms": [
+        {
+          "href": "mqtt://test.mosquitto.org:1884",
+          "mqv:topic": "test",
+          "mqv:retain": true,
+        }
+      ],
     },
-    "actions": {
-      "toggle": {
-        "input": {
-          "type": "string"
-        },
-        "forms": [
-          {
-            "href": "mqtt://test.mosquitto.org:1884",
-            "mqv:topic": "test",
-            "mqv:retain": true
-          }
-        ]
-      }
-    }
-  }
-  ''';
+  },
+};
 
 final Map<String, BasicCredentials> basicCredentials = {
   "urn:test": BasicCredentials("rw", "readwrite"),
@@ -56,10 +50,10 @@ final Map<String, BasicCredentials> basicCredentials = {
 
 Future<BasicCredentials?> basicCredentialsCallback(
   Uri uri,
-  Form? form, [
+  AugmentedForm? form, [
   BasicCredentials? invalidCredentials,
 ]) async {
-  final id = form?.thingDescription.identifier;
+  final id = form?.tdIdentifier;
 
   return basicCredentials[id];
 }
@@ -73,7 +67,7 @@ Future<void> main(List<String> args) async {
 
   final wot = await servient.start();
 
-  final thingDescription = ThingDescription(thingDescriptionJson);
+  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
   await consumedThing.readAndPrintProperty("status");
 

--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -67,7 +67,7 @@ Future<void> main(List<String> args) async {
 
   final wot = await servient.start();
 
-  final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
+  final thingDescription = thingDescriptionJson.toThingDescription();
   final consumedThing = await wot.consume(thingDescription);
   await consumedThing.readAndPrintProperty("status");
 

--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -87,7 +87,9 @@ Future<void> main(List<String> args) async {
   await consumedThing.invokeAction("toggle", input: actionInput);
   await subscription.stop();
 
-  await consumedThing.invokeAction("toggle", input: actionInput);
+  final actionInput2 = "Bye World".asInteractionInput();
+
+  await consumedThing.invokeAction("toggle", input: actionInput2);
   await consumedThing.readAndPrintProperty("status");
   print("Done!");
 }

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -11,6 +11,7 @@ library core;
 
 export "package:dcaf/dcaf.dart";
 
+export "src/core/augmented_form.dart";
 export "src/core/codecs/content_codec.dart";
 export "src/core/content_serdes.dart";
 export "src/core/credentials/ace_credentials.dart";

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -11,6 +11,7 @@ import "package:coap/coap.dart" as coap;
 import "package:coap/config/coap_config_default.dart";
 import "package:dcaf/dcaf.dart";
 
+import "../core/augmented_form.dart";
 import "../core/content.dart";
 import "../core/credentials/ace_credentials.dart";
 import "../core/credentials/callbacks.dart";
@@ -52,7 +53,7 @@ class _InternalCoapConfig extends CoapConfigDefault {
 
 coap.PskCredentialsCallback? _createPskCallback(
   Uri uri,
-  Form? form, {
+  AugmentedForm? form, {
   ClientPskCallback? pskCredentialsCallback,
 }) {
   final usesPskScheme = form?.usesPskScheme ?? false;
@@ -126,7 +127,7 @@ final class CoapClient implements ProtocolClient {
   }
 
   Future<Content> _sendRequestFromForm(
-    Form form,
+    AugmentedForm form,
     OperationType operationType, [
     Content? content,
   ]) async {
@@ -151,7 +152,7 @@ final class CoapClient implements ProtocolClient {
     Uri uri,
     coap.RequestMethod method, {
     Content? content,
-    required Form? form,
+    required AugmentedForm? form,
     coap.CoapMediaType? format,
     coap.CoapMediaType? accept,
     coap.BlockSize? block1Size,
@@ -207,7 +208,7 @@ final class CoapClient implements ProtocolClient {
     Uri uri,
     coap.RequestMethod method, {
     Content? content,
-    required Form? form,
+    required AugmentedForm? form,
     coap.CoapMediaType? format,
     coap.CoapMediaType? accept,
     coap.BlockSize? block1Size,
@@ -230,7 +231,7 @@ final class CoapClient implements ProtocolClient {
   }
 
   Future<AuthServerRequestCreationHint?> _obtainCreationHintFromResourceServer(
-    Form form,
+    AugmentedForm form,
   ) async {
     final requestMethod = (form.method ?? CoapRequestMethod.get).code;
 
@@ -259,7 +260,7 @@ final class CoapClient implements ProtocolClient {
   ///
   /// Returns `null` if no `ACESecurityScheme` is defined.
   Future<AuthServerRequestCreationHint?> _obtainAceCreationHintFromForm(
-    Form? form,
+    AugmentedForm? form,
   ) async {
     if (form == null) {
       return null;
@@ -301,7 +302,7 @@ final class CoapClient implements ProtocolClient {
     AuthServerRequestCreationHint? creationHint,
     AceSecurityCallback aceCredentialsCallback,
     Uri uri,
-    Form? form, [
+    AugmentedForm? form, [
     AceCredentials? invalidAceCredentials,
   ]) async {
     final aceCredentials = await aceCredentialsCallback(
@@ -339,7 +340,7 @@ final class CoapClient implements ProtocolClient {
     coap.CoapRequest request,
     coap.CoapResponse response,
     Uri uri,
-    Form? form,
+    AugmentedForm? form,
     AceSecurityCallback aceCredentialsCallback, {
     AceCredentials? invalidAceCredentials,
   }) async {
@@ -372,23 +373,23 @@ final class CoapClient implements ProtocolClient {
   }
 
   @override
-  Future<Content> readResource(Form form) async {
+  Future<Content> readResource(AugmentedForm form) async {
     return _sendRequestFromForm(form, OperationType.readproperty);
   }
 
   @override
-  Future<void> writeResource(Form form, Content content) async {
+  Future<void> writeResource(AugmentedForm form, Content content) async {
     await _sendRequestFromForm(form, OperationType.writeproperty, content);
   }
 
   @override
-  Future<Content> invokeResource(Form form, Content content) async {
+  Future<Content> invokeResource(AugmentedForm form, Content content) async {
     return _sendRequestFromForm(form, OperationType.invokeaction, content);
   }
 
   @override
   Future<Subscription> subscribeResource(
-    Form form, {
+    AugmentedForm form, {
     required void Function(Content content) next,
     void Function(Exception error)? error,
     required void Function() complete,
@@ -406,7 +407,7 @@ final class CoapClient implements ProtocolClient {
   }
 
   Future<CoapSubscription> _startObservation(
-    Form form,
+    AugmentedForm form,
     OperationType operationType,
     void Function(Content content) next,
     void Function() complete,

--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -5,6 +5,7 @@ import "package:cbor/cbor.dart";
 import "package:coap/coap.dart";
 import "package:dcaf/dcaf.dart";
 
+import "../core/augmented_form.dart";
 import "../core/content.dart";
 import "../definitions/expected_response.dart";
 import "../definitions/form.dart";
@@ -26,7 +27,7 @@ extension InternetAddressMethods on Uri {
 }
 
 /// CoAP-specific extensions for the [Form] class.
-extension CoapFormExtension on Form {
+extension CoapFormExtension on AugmentedForm {
   T? _obtainVocabularyTerm<T>(String vocabularyTerm) {
     final curieString = coapPrefixMapping.expandCurieString(vocabularyTerm);
     final formDefinition = additionalFields[curieString];

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -9,6 +9,7 @@ import "dart:io";
 
 import "package:http/http.dart";
 
+import "../core/augmented_form.dart";
 import "../core/content.dart";
 import "../core/credentials/basic_credentials.dart";
 import "../core/credentials/bearer_credentials.dart";
@@ -60,7 +61,10 @@ final class HttpClient implements ProtocolClient {
   final AsyncClientSecurityCallback<BearerCredentials>?
       _bearerCredentialsCallback;
 
-  Future<void> _applyCredentialsFromForm(Request request, Form form) async {
+  Future<void> _applyCredentialsFromForm(
+    Request request,
+    AugmentedForm form,
+  ) async {
     // TODO(JKRhb): Add DigestSecurity back in
     if (await _applyBearerCredentialsFromForm(request, form)) {
       return;
@@ -73,7 +77,7 @@ final class HttpClient implements ProtocolClient {
 
   Future<bool> _applyBasicCredentialsFromForm(
     Request request,
-    Form form,
+    AugmentedForm form,
   ) async {
     final basicSecuritySchemes =
         form.securityDefinitions.whereType<BasicSecurityScheme>();
@@ -96,7 +100,7 @@ final class HttpClient implements ProtocolClient {
 
   Future<bool> _applyBearerCredentialsFromForm(
     Request request,
-    Form form,
+    AugmentedForm form,
   ) async {
     final bearerSecuritySchemes =
         form.securityDefinitions.whereType<BearerSecurityScheme>();
@@ -141,7 +145,7 @@ final class HttpClient implements ProtocolClient {
 
   Future<StreamedResponse> _createBasicAuthRequest(
     Request originalRequest,
-    Form? form,
+    AugmentedForm? form,
   ) async {
     final request = _copyRequest(originalRequest);
     final basicCredentials = await _getBasicCredentials(request.url, form);
@@ -157,7 +161,7 @@ final class HttpClient implements ProtocolClient {
 
   Future<StreamedResponse> _createBearerAuthRequest(
     Request originalRequest,
-    Form? form,
+    AugmentedForm? form,
   ) async {
     final request = _copyRequest(originalRequest);
     final bearerCredentials = await _getBearerCredentials(request.url, form);
@@ -174,7 +178,7 @@ final class HttpClient implements ProtocolClient {
   Future<StreamedResponse> _handleResponse(
     Request originalRequest,
     StreamedResponse response, [
-    Form? form,
+    AugmentedForm? form,
   ]) async {
     if (response.statusCode == HttpStatus.unauthorized) {
       final authenticate = response.headers["www-authenticate"];
@@ -194,7 +198,7 @@ final class HttpClient implements ProtocolClient {
   }
 
   Future<StreamedResponse> _createRequest(
-    Form form,
+    AugmentedForm form,
     OperationType operationType,
     Content? content,
   ) async {
@@ -215,7 +219,7 @@ final class HttpClient implements ProtocolClient {
 
   Future<BasicCredentials?> _getBasicCredentials(
     Uri uri,
-    Form? form, [
+    AugmentedForm? form, [
     BasicCredentials? invalidCredentials,
   ]) async {
     return _basicCredentialsCallback?.call(uri, form, invalidCredentials);
@@ -223,7 +227,7 @@ final class HttpClient implements ProtocolClient {
 
   Future<BearerCredentials?> _getBearerCredentials(
     Uri uri,
-    Form? form, [
+    AugmentedForm? form, [
     BearerCredentials? invalidCredentials,
   ]) async {
     return _bearerCredentialsCallback?.call(uri, form, invalidCredentials);
@@ -255,14 +259,14 @@ final class HttpClient implements ProtocolClient {
   }
 
   @override
-  Future<Content> invokeResource(Form form, Content content) async {
+  Future<Content> invokeResource(AugmentedForm form, Content content) async {
     final response =
         await _createRequest(form, OperationType.invokeaction, content);
     return _contentFromResponse(form, response);
   }
 
   @override
-  Future<Content> readResource(Form form) async {
+  Future<Content> readResource(AugmentedForm form) async {
     final response =
         await _createRequest(form, OperationType.readproperty, null);
     return _contentFromResponse(form, response);
@@ -279,7 +283,7 @@ final class HttpClient implements ProtocolClient {
   }
 
   @override
-  Future<void> writeResource(Form form, Content content) async {
+  Future<void> writeResource(AugmentedForm form, Content content) async {
     await _createRequest(form, OperationType.writeproperty, content);
   }
 

--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -10,11 +10,11 @@ import "package:mqtt_client/mqtt_client.dart";
 import "package:mqtt_client/mqtt_server_client.dart";
 import "package:typed_data/typed_buffers.dart";
 
+import "../core/augmented_form.dart";
 import "../core/content.dart";
 import "../core/credentials/basic_credentials.dart";
 import "../core/credentials/callbacks.dart";
 import "../core/protocol_interfaces/protocol_client.dart";
-import "../definitions/form.dart";
 import "../scripting_api/subscription.dart" as scripting_api;
 import "constants.dart";
 import "mqtt_binding_exception.dart";
@@ -40,7 +40,7 @@ final class MqttClient implements ProtocolClient {
 
   Future<BasicCredentials?> _obtainCredentials(
     Uri uri,
-    Form? form, [
+    AugmentedForm? form, [
     BasicCredentials? invalidCredentials,
     bool unauthorized = false,
   ]) async {
@@ -71,10 +71,10 @@ final class MqttClient implements ProtocolClient {
     );
   }
 
-  Future<MqttServerClient> _connectWithForm(Form form) async =>
+  Future<MqttServerClient> _connectWithForm(AugmentedForm form) async =>
       _connect(form.resolvedHref, form);
 
-  Future<MqttServerClient> _connect(Uri brokerUri, Form? form) async {
+  Future<MqttServerClient> _connect(Uri brokerUri, AugmentedForm? form) async {
     final client = brokerUri.createClient(_mqttConfig.keepAlivePeriod);
     final credentials = await _obtainCredentials(brokerUri, form);
 
@@ -99,7 +99,7 @@ final class MqttClient implements ProtocolClient {
   }
 
   @override
-  Future<Content> invokeResource(Form form, Content content) async {
+  Future<Content> invokeResource(AugmentedForm form, Content content) async {
     final client = await _connectWithForm(form);
     final topic = form.topicName;
     final qualityOfService =
@@ -118,7 +118,7 @@ final class MqttClient implements ProtocolClient {
   }
 
   @override
-  Future<Content> readResource(Form form) async {
+  Future<Content> readResource(AugmentedForm form) async {
     final client = await _connectWithForm(form);
     final topic = form.topicFilter;
     final qualityOfService =
@@ -154,7 +154,7 @@ final class MqttClient implements ProtocolClient {
   }
 
   @override
-  Future<void> writeResource(Form form, Content content) async {
+  Future<void> writeResource(AugmentedForm form, Content content) async {
     final client = await _connectWithForm(form);
     final topic = form.topicName;
     final qualityOfService =
@@ -182,7 +182,7 @@ final class MqttClient implements ProtocolClient {
 
   @override
   Future<scripting_api.Subscription> subscribeResource(
-    Form form, {
+    AugmentedForm form, {
     required void Function(Content content) next,
     void Function(Exception error)? error,
     required void Function() complete,

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -9,7 +9,8 @@ import "package:mqtt_client/mqtt_client.dart";
 import "package:mqtt_client/mqtt_server_client.dart";
 import "package:uuid/uuid.dart";
 
-import "../../core.dart";
+import "../core/augmented_form.dart";
+import "../core/credentials/basic_credentials.dart";
 import "../definitions/form.dart";
 import "../definitions/security/auto_security_scheme.dart";
 import "../definitions/security/basic_security_scheme.dart";
@@ -66,7 +67,7 @@ extension MqttUriExtension on Uri {
 }
 
 /// Additional methods for making MQTT [Form]s easier to work with.
-extension MqttFormExtension on Form {
+extension MqttFormExtension on AugmentedForm {
   /// Indicates if this [Form] requires basic authentication.
   bool requiresBasicAuthencation(BasicCredentials? credentials) {
     if (_hasBasicSecurityScheme) {
@@ -145,7 +146,7 @@ extension MqttFormExtension on Form {
       throw ValidationException(
         "Encountered unknown QoS value $qosValue. "
         "in form with href $href of Thing Description with Identifier "
-        "${thingDescription.identifier}.",
+        "$tdIdentifier.",
       );
     }
 

--- a/lib/src/core/augmented_form.dart
+++ b/lib/src/core/augmented_form.dart
@@ -1,0 +1,201 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:collection/collection.dart";
+import "package:json_schema/json_schema.dart";
+import "package:meta/meta.dart";
+import "package:uri/uri.dart";
+
+import "../definitions/additional_expected_response.dart";
+import "../definitions/expected_response.dart";
+import "../definitions/form.dart";
+import "../definitions/interaction_affordances/interaction_affordance.dart";
+import "../definitions/operation_type.dart";
+import "../definitions/security/security_scheme.dart";
+import "../definitions/thing_description.dart";
+import "../definitions/validation/validation_exception.dart";
+
+/// A [Form] augmented with information from its asscociated [_thingDescription]
+/// and [_interactionAffordance].
+@immutable
+final class AugmentedForm implements Form {
+  /// Creates a new augmented [Form].
+  const AugmentedForm(
+    this._form,
+    this._interactionAffordance,
+    this._thingDescription,
+    this._userProvidedUriVariables,
+  );
+
+  final Form _form;
+
+  final ThingDescription _thingDescription;
+
+  final InteractionAffordance _interactionAffordance;
+
+  final Map<String, Object>? _userProvidedUriVariables;
+
+  /// The identifier of the [_thingDescription] associated with this form.
+  String get tdIdentifier => _thingDescription.identifier;
+
+  @override
+  Map<String, dynamic> get additionalFields => _form.additionalFields;
+
+  @override
+  List<AdditionalExpectedResponse>? get additionalResponses =>
+      _form.additionalResponses;
+
+  @override
+  String? get contentCoding => _form.contentCoding;
+
+  @override
+  String get contentType => _form.contentType;
+
+  @override
+  Uri get href {
+    final baseUri = _thingDescription.base;
+
+    if (baseUri != null) {
+      return baseUri.resolveUri(_form.href);
+    }
+
+    return _form.href;
+  }
+
+  @override
+  List<OperationType> get op =>
+      _form.op ?? OperationType.defaultOpValues(_interactionAffordance);
+
+  @override
+  ExpectedResponse? get response => _form.response;
+
+  @override
+  List<String>? get scopes => _form.scopes;
+
+  @override
+  List<String> get security => _form.security ?? _thingDescription.security;
+
+  @override
+  String? get subprotocol => _form.subprotocol;
+
+  /// The computed [List] of [SecurityScheme]s associated with this form.
+  ///
+  /// The list is derived from the [_thingDescription] and the [security] keys
+  /// defined for the form.
+  List<SecurityScheme> get securityDefinitions =>
+      _thingDescription.securityDefinitions.entries
+          .where(
+            (securityDefinition) => security.contains(securityDefinition.key),
+          )
+          .map((securityDefinition) => securityDefinition.value)
+          .toList();
+
+  List<String> _filterUriVariables(Uri href) {
+    final regex = RegExp("{[?+#./;&]?([^}]*)}");
+    final decodedUri = Uri.decodeFull(href.toString());
+    return regex
+        .allMatches(decodedUri)
+        .map((e) => e.group(1))
+        .whereType<String>()
+        .map((e) => e.split(","))
+        .flattened
+        .toList(growable: false);
+  }
+
+  /// Resolves all [_userProvidedUriVariables] in this [Form] and returns the
+  /// resulting [Uri].
+  Uri get resolvedHref {
+    final hrefUriVariables = _filterUriVariables(href);
+
+    if (hrefUriVariables.isEmpty) {
+      return href;
+    }
+
+    final Map<String, Object> affordanceUriVariables = {
+      ..._thingDescription.uriVariables ?? {},
+      ..._interactionAffordance.uriVariables ?? {},
+    };
+
+    final userProvidedUriVariables = _userProvidedUriVariables;
+    if (userProvidedUriVariables != null) {
+      _validateUriVariables(
+        hrefUriVariables,
+        affordanceUriVariables,
+        userProvidedUriVariables,
+      );
+    }
+
+    // As "{" and "}" are "percent encoded" due to Uri.parse(), we need to
+    // revert the encoding first before we can insert the values.
+    final decodedHref = Uri.decodeFull(href.toString());
+
+    final expandedHref =
+        UriTemplate(decodedHref).expand(userProvidedUriVariables ?? {});
+    return Uri.parse(expandedHref);
+  }
+
+  void _validateUriVariables(
+    List<String> uriVariablesInHref,
+    Map<String, Object> affordanceUriVariables,
+    Map<String, Object> userProvidedUriVariables,
+  ) {
+    final uncoveredHrefUriVariables = uriVariablesInHref
+        .where((element) => !affordanceUriVariables.containsKey(element));
+
+    if (uncoveredHrefUriVariables.isNotEmpty) {
+      throw ValidationException(
+          "The following URI template variables defined in the form's href "
+          "but are not covered by a uriVariable entry at the TD or affordance "
+          "level: ${uncoveredHrefUriVariables.join(", ")}.");
+    }
+
+    final missingTdLevelUserInput = uriVariablesInHref.where(
+      (uriVariableName) =>
+          !userProvidedUriVariables.containsKey(uriVariableName),
+    );
+
+    if (missingTdLevelUserInput.isNotEmpty) {
+      throw UriVariableException(
+        "The following URI template variables defined at the TD level are not "
+        "covered by the values provided by the user: "
+        "${missingTdLevelUserInput.join(", ")}. "
+        "Values for the following variables were received: "
+        "${userProvidedUriVariables.keys.join(", ")}.",
+      );
+    }
+
+    // We now assert that all user provided values comply to the Schema
+    // definition in the TD.
+    for (final affordanceUriVariable in affordanceUriVariables.entries) {
+      final key = affordanceUriVariable.key;
+      final value = affordanceUriVariable.value;
+
+      final schema = JsonSchema.create(value);
+      final result = schema.validate(userProvidedUriVariables[key]);
+
+      if (!result.isValid) {
+        throw ValidationException("Invalid type for URI variable $key");
+      }
+    }
+  }
+}
+
+/// This [Exception] is thrown when [URI variables] are being used in the [Form]
+/// of a TD but no (valid) values were provided.
+///
+/// [URI variables]: https://www.w3.org/TR/wot-thing-description11/#form-uriVariables
+class UriVariableException implements Exception {
+  /// Constructor.
+  UriVariableException(this.message);
+
+  /// The error [message].
+  final String message;
+
+  @override
+  String toString() {
+    return "UriVariableException: $message";
+  }
+}

--- a/lib/src/core/credentials/callbacks.dart
+++ b/lib/src/core/credentials/callbacks.dart
@@ -7,6 +7,7 @@
 import "package:dcaf/dcaf.dart";
 
 import "../../definitions/form.dart";
+import "../augmented_form.dart";
 import "ace_credentials.dart";
 import "credentials.dart";
 import "psk_credentials.dart";
@@ -59,7 +60,7 @@ typedef AceSecurityCallback = Future<AceCredentials?> Function(
 /// This callback signature is currently only used for [PskCredentials] due to
 /// implementation limititations, which do not allow for asynchronous callbacks.
 typedef AsyncClientSecurityCallback<T extends Credentials> = Future<T?>
-    Function(Uri uri, Form? form, T? invalidCredentials);
+    Function(Uri uri, AugmentedForm? form, T? invalidCredentials);
 
 /// Function signature for a synchronous callback retrieving server
 /// [Credentials] by Thing [id] at runtime.

--- a/lib/src/core/exposed_thing.dart
+++ b/lib/src/core/exposed_thing.dart
@@ -7,9 +7,7 @@
 import "../../definitions.dart";
 import "../../scripting_api.dart" hide ExposedThing;
 import "../../scripting_api.dart" as scripting_api;
-import "../definitions/interaction_affordances/action.dart";
-import "../definitions/interaction_affordances/event.dart";
-import "../definitions/interaction_affordances/property.dart";
+import "../definitions/interaction_affordances/interaction_affordance.dart";
 import "servient.dart";
 
 /// Implemention of the [scripting_api.ExposedThing] interface.
@@ -17,31 +15,13 @@ class ExposedThing implements scripting_api.ExposedThing {
   /// Creates a new [ExposedThing] from a [servient] and an [exposedThingInit].
   ExposedThing(this.servient, ExposedThingInit exposedThingInit)
       : thingDescription =
-            ThingDescription.fromJson(exposedThingInit, validate: false) {
-    title = thingDescription.title;
-    id = thingDescription.id;
-  }
-
-  /// Creates an [ExposedThing] from a [ThingModel].
-  ///
-  // TODO(JKRhb): Additional parameters for bindings etc. might be needed
-  ExposedThing.fromThingModel(this.servient, ThingModel thingModel)
-      : thingDescription = ThingDescription.fromThingModel(thingModel) {
-    title = thingDescription.title;
-    id = thingDescription.id;
-  }
+            ThingDescription.fromJson(exposedThingInit, validate: false);
 
   @override
   final ThingDescription thingDescription;
 
   /// The [Servient] associated with this [ExposedThing].
   final Servient servient;
-
-  /// A unique identifier of this [ExposedThing].
-  String? id;
-
-  /// The title of the Thing.
-  String? title;
 
   /// A [Map] of all the [properties] of this [ExposedThing].
   final Map<String, Property>? properties = {};

--- a/lib/src/core/protocol_interfaces/protocol_client.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "../../definitions/form.dart";
 import "../../scripting_api/subscription.dart";
+import "../augmented_form.dart";
 import "../content.dart";
 
 /// Base class for a Protocol Client.
@@ -44,20 +44,20 @@ abstract interface class ProtocolClient {
   Stream<DiscoveryContent> discoverWithCoreLinkFormat(Uri uri);
 
   /// Requests the client to perform a `readproperty` operation on a [form].
-  Future<Content> readResource(Form form);
+  Future<Content> readResource(AugmentedForm form);
 
   /// Requests the client to perform a `writeproperty` operation on a [form]
   /// using the given [content].
-  Future<void> writeResource(Form form, Content content);
+  Future<void> writeResource(AugmentedForm form, Content content);
 
   /// Requests the client to perform an `invokeaction` operation on a [form]
   /// using the given [content].
-  Future<Content> invokeResource(Form form, Content content);
+  Future<Content> invokeResource(AugmentedForm form, Content content);
 
   /// Requests the client to perform a `subscribeproperty` operation on a
   /// [form].
   Future<Subscription> subscribeResource(
-    Form form, {
+    AugmentedForm form, {
     required void Function(Content content) next,
     void Function(Exception error)? error,
     required void Function() complete,

--- a/lib/src/core/servient.dart
+++ b/lib/src/core/servient.dart
@@ -4,8 +4,6 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "package:uuid/uuid.dart";
-
 import "../definitions/interaction_affordances/interaction_affordance.dart";
 import "../definitions/thing_description.dart";
 import "../scripting_api/data_schema_value.dart";
@@ -132,14 +130,12 @@ class Servient {
   /// Returns `false` if the [thing] has already been registered, otherwise
   /// `true`.
   bool addThing(ExposedThing thing) {
-    const uuid = Uuid();
-    thing.id ??= "urn:uuid:${uuid.v4()}";
-
-    if (_things.containsKey(thing.id)) {
+    final id = thing.thingDescription.identifier;
+    if (_things.containsKey(id)) {
       return false;
     }
 
-    _things[thing.id!] = thing;
+    _things[id] = thing;
     return true;
   }
 

--- a/lib/src/core/wot.dart
+++ b/lib/src/core/wot.dart
@@ -136,7 +136,7 @@ class WoT implements scripting_api.WoT {
 
     final thingDescriptionStream = Stream.fromIterable(
       rawThingDescriptions.whereType<Map<String, Object?>>(),
-    ).toThingDescriptionStream();
+    ).map((rawThingDescription) => rawThingDescription.toThingDescription());
 
     return ThingDiscoveryProcess(thingDescriptionStream, filter);
   }
@@ -160,40 +160,5 @@ extension _DirectoryValidationExtension on ThingDescription {
 
     return context.contains((value: discoveryContextUri, key: null)) &&
         atTypes.contains(type);
-  }
-}
-
-extension _DirectoryTdDeserializationExtension on Stream<Map<String, Object?>> {
-  Stream<ThingDescription> toThingDescriptionStream() {
-    const streamTransformer = StreamTransformer(_transformerMethod);
-
-    return transform(streamTransformer);
-  }
-
-  static StreamSubscription<ThingDescription> _transformerMethod(
-    Stream<Map<String, dynamic>> rawThingDescriptionStream,
-    bool cancelOnError,
-  ) {
-    final streamController = StreamController<ThingDescription>();
-
-    final streamSubscription = rawThingDescriptionStream.listen(
-      (rawThingDescription) {
-        try {
-          streamController.add(ThingDescription.fromJson(rawThingDescription));
-        } on Exception catch (exception) {
-          streamController.addError(exception);
-        }
-      },
-      onDone: streamController.close,
-      onError: streamController.addError,
-      cancelOnError: cancelOnError,
-    );
-
-    streamController
-      ..onPause = streamSubscription.pause
-      ..onResume = streamSubscription.resume
-      ..onCancel = streamSubscription.cancel;
-
-    return streamController.stream.listen(null);
   }
 }

--- a/lib/src/core/wot.dart
+++ b/lib/src/core/wot.dart
@@ -6,6 +6,8 @@
 
 import "dart:async";
 
+import "package:uuid/uuid.dart";
+
 import "../../scripting_api.dart" as scripting_api;
 import "../definitions/thing_description.dart";
 import "../scripting_api/discovery/discovery_method.dart";
@@ -76,7 +78,14 @@ class WoT implements scripting_api.WoT {
   /// Exposes a Thing based on a (partial) TD.
   @override
   Future<scripting_api.ExposedThing> produce(Map<String, dynamic> init) async {
-    final newThing = ExposedThing(_servient, init);
+    const uuid = Uuid();
+
+    final exposedThingInit = {
+      "id": "urn:uuid:${uuid.v4()}",
+      ...init,
+    };
+
+    final newThing = ExposedThing(_servient, exposedThingInit);
     if (_servient.addThing(newThing)) {
       return newThing;
     } else {

--- a/lib/src/definitions/additional_expected_response.dart
+++ b/lib/src/definitions/additional_expected_response.dart
@@ -15,13 +15,12 @@ import "extensions/json_parser.dart";
 @immutable
 class AdditionalExpectedResponse {
   /// Constructs a new [AdditionalExpectedResponse] object from a [contentType].
-  AdditionalExpectedResponse(
+  const AdditionalExpectedResponse(
     this.contentType, {
     this.schema,
-    bool? success,
-    Map<String, dynamic>? additionalFields,
-  })  : additionalFields = additionalFields ?? {},
-        success = success ?? false;
+    this.success = false,
+    this.additionalFields,
+  });
 
   /// Creates an [AdditionalExpectedResponse] from a [json] object.
   factory AdditionalExpectedResponse.fromJson(
@@ -33,7 +32,7 @@ class AdditionalExpectedResponse {
 
     final contentType =
         json.parseField<String>("contentType", parsedFields) ?? formContentType;
-    final success = json.parseField<bool>("success", parsedFields);
+    final success = json.parseField<bool>("success", parsedFields) ?? false;
     final schema = json.parseField<String>("schema", parsedFields);
     final additionalFields =
         json.parseAdditionalFields(prefixMapping, parsedFields);

--- a/lib/src/definitions/data_schema.dart
+++ b/lib/src/definitions/data_schema.dart
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import "package:curie/curie.dart";
+import "package:meta/meta.dart";
 
 import "extensions/json_parser.dart";
 
@@ -13,9 +14,10 @@ import "extensions/json_parser.dart";
 /// See W3C WoT Thing Description specification, [section 5.3.2.1][spec link].
 ///
 /// [spec link]: https://w3c.github.io/wot-thing-description/#dataschema
+@immutable
 class DataSchema {
   /// Constructor
-  DataSchema({
+  const DataSchema({
     this.atType,
     this.title,
     this.titles,

--- a/lib/src/definitions/expected_response.dart
+++ b/lib/src/definitions/expected_response.dart
@@ -5,19 +5,19 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import "package:curie/curie.dart";
+import "package:meta/meta.dart";
 
 import "extensions/json_parser.dart";
 
 /// Communication metadata describing the expected response message for the
 /// primary response.
+@immutable
 class ExpectedResponse {
   /// Constructs a new [ExpectedResponse] object from a [contentType].
-  ExpectedResponse(this.contentType, {Map<String, dynamic>? additionalFields})
-      : additionalFields = Map.fromEntries(
-          additionalFields?.entries
-                  .where((element) => element.key != "contentType") ??
-              [],
-        );
+  const ExpectedResponse(
+    this.contentType, {
+    this.additionalFields,
+  });
 
   /// Creates an [ExpectedResponse] from a [json] object.
   factory ExpectedResponse.fromJson(
@@ -35,7 +35,7 @@ class ExpectedResponse {
   }
 
   /// The [contentType] of this [ExpectedResponse] object.
-  String contentType;
+  final String contentType;
 
   /// Any other additional field will be included in this [Map].
   final Map<String, dynamic>? additionalFields;

--- a/lib/src/definitions/form.dart
+++ b/lib/src/definitions/form.dart
@@ -5,43 +5,31 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import "package:curie/curie.dart";
-import "package:json_schema/json_schema.dart";
-import "package:uri/uri.dart";
+import "package:meta/meta.dart";
 
-import "../../dart_wot.dart";
 import "additional_expected_response.dart";
 import "expected_response.dart";
 import "extensions/json_parser.dart";
-import "interaction_affordances/action.dart";
-import "interaction_affordances/event.dart";
-import "interaction_affordances/interaction_affordance.dart";
-import "interaction_affordances/property.dart";
 import "operation_type.dart";
-import "security/security_scheme.dart";
-import "validation/validation_exception.dart";
 
 /// Contains the information needed for performing interactions with a Thing.
+@immutable
 class Form {
   /// Creates a new [Form] object.
   ///
   /// An [href] has to be provided. A [contentType] is optional.
   Form(
-    this.href,
-    this.thingDescription, {
-    this.interactionAffordance,
+    this.href, {
     this.contentType = "application/json",
     this.contentCoding,
     this.subprotocol,
     this.security,
-    List<String>? op,
+    this.op,
     this.scopes,
     this.response,
     this.additionalResponses,
     Map<String, dynamic>? additionalFields,
-  })  : resolvedHref = _expandHref(href, thingDescription),
-        securityDefinitions =
-            _filterSecurityDefinitions(thingDescription, security),
-        op = _setOpValue(interactionAffordance, op) {
+  }) {
     if (additionalFields != null) {
       this.additionalFields.addAll(additionalFields);
     }
@@ -51,15 +39,13 @@ class Form {
   factory Form.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
-    ThingDescription thingDescription, [
-    InteractionAffordance? interactionAffordance,
-  ]) {
+  ) {
     final Set<String> parsedFields = {};
     final href = json.parseRequiredUriField("href", parsedFields);
 
     final subprotocol = json.parseField<String>("subprotocol", parsedFields);
 
-    final List<String>? op = json.parseArrayField<String>("op", parsedFields);
+    final op = json.parseOperationTypes(parsedFields);
 
     final contentType = json.parseField<String>("contentType", parsedFields) ??
         "application/json";
@@ -82,8 +68,6 @@ class Form {
 
     return Form(
       href,
-      thingDescription,
-      interactionAffordance: interactionAffordance,
       contentType: contentType,
       contentCoding: contentCoding,
       subprotocol: subprotocol,
@@ -101,29 +85,14 @@ class Form {
   /// Can be a relative or absolute URI.
   final Uri href;
 
-  /// An absolute [Uri], which is either the original [href] or a resolved
-  /// version using the base [Uri] of the Thing Description.
-  final Uri resolvedHref;
-
-  /// The [SecurityScheme]s used by this [Form].
-  final List<SecurityScheme> securityDefinitions;
-
-  /// Reference to the [ThingDescription] containing this [Form].
-  final ThingDescription thingDescription;
-
-  /// Reference to the [InteractionAffordance] containing this [Form].
-  ///
-  /// Might be `null` if the [Form] is defined at the [ThingDescription] level.
-  final InteractionAffordance? interactionAffordance;
-
   /// The subprotocol that is used with this [Form].
-  String? subprotocol;
+  final String? subprotocol;
 
   /// The operation types supported by this [Form].
-  final List<OperationType> op;
+  final List<OperationType>? op;
 
   /// The [contentType] supported by this [Form].
-  String contentType = "application/json";
+  final String contentType;
 
   /// The content coding supported by this [Form].
   ///
@@ -133,16 +102,16 @@ class Form {
   /// compressed or otherwise usefully transformed without losing the identity
   /// of its underlying media type and without loss of information.
   /// Examples of content coding include "gzip", "deflate", etc.
-  String? contentCoding;
+  final String? contentCoding;
 
   /// The list of [security] definitions applied to this [Form].
-  List<String>? security;
+  final List<String>? security;
 
   /// A list of OAuth2 scopes that are supposed to be used with this [Form].
-  List<String>? scopes;
+  final List<String>? scopes;
 
   /// The [response] a consumer can expect from interacting with this [Form].
-  ExpectedResponse? response;
+  final ExpectedResponse? response;
 
   /// This optional term can be used if additional expected responses are
   /// possible, e.g. for error reporting.
@@ -150,208 +119,8 @@ class Form {
   /// Each additional response needs to be distinguished from others in some way
   /// (for example, by specifying a protocol-specific error code), and may also
   ///  have its own data schema.
-  List<AdditionalExpectedResponse>? additionalResponses;
+  final List<AdditionalExpectedResponse>? additionalResponses;
 
   /// Additional fields collected during the parsing of a JSON object.
   final Map<String, dynamic> additionalFields = {};
-
-  static List<SecurityScheme> _filterSecurityDefinitions(
-    ThingDescription thingDescription,
-    List<String>? security,
-  ) {
-    final securityKeys = security ?? thingDescription.security;
-    final securityDefinitions = thingDescription.securityDefinitions;
-
-    return securityKeys.map((securityKey) {
-      final securityDefinition = securityDefinitions[securityKey];
-
-      if (securityDefinition == null) {
-        throw ValidationException(
-          "Form requires a security definition with "
-          "key $securityKey, but the Thing Description does not define a "
-          "security definition with such a key!",
-        );
-      }
-
-      return securityDefinition;
-    }).toList();
-  }
-
-  static Uri _expandHref(
-    Uri href,
-    ThingDescription thingDescription,
-  ) {
-    final base = thingDescription.base;
-    if (href.isAbsolute) {
-      return href;
-    } else if (base != null) {
-      return base.resolveUri(href);
-    } else {
-      throw ValidationException(
-        "The form's $href is not an absolute URI, "
-        "but the Thing Description does not provide a base field!",
-      );
-    }
-  }
-
-  static List<OperationType> _setOpValue(
-    InteractionAffordance? interactionAffordance,
-    List<String>? opStrings,
-  ) {
-    if (opStrings != null) {
-      return opStrings.map(OperationType.fromString).toList();
-    }
-
-    if (interactionAffordance == null) {
-      return [];
-    }
-
-    if (interactionAffordance is Action) {
-      return [OperationType.invokeaction];
-    } else if (interactionAffordance is Property) {
-      final List<OperationType> op = [];
-      if (!interactionAffordance.readOnly) {
-        op.add(OperationType.readproperty);
-      }
-      if (!interactionAffordance.writeOnly) {
-        op.add(OperationType.writeproperty);
-      }
-      return op;
-    } else if (interactionAffordance is Event) {
-      return [OperationType.subscribeevent, OperationType.unsubscribeevent];
-    }
-
-    throw StateError(
-      "Encountered unknown InteractionAffordance "
-      "${interactionAffordance.runtimeType}.",
-    );
-  }
-
-  /// Creates a deep copy of this [Form].
-  Form _copy(Uri newHref) {
-    // TODO(JKRhb): Make deep copies of security, scopes, and response.
-    final copiedForm = Form(
-      newHref,
-      thingDescription,
-      interactionAffordance: interactionAffordance,
-      op: op.map((opValue) => opValue.name).toList(),
-      contentType: contentType,
-      subprotocol: subprotocol,
-      security: security,
-      scopes: scopes,
-      response: response,
-      additionalFields: <String, dynamic>{}..addAll(additionalFields),
-    );
-    return copiedForm;
-  }
-
-  void _validateUriVariables(
-    List<String> hrefUriVariables,
-    Map<String, Object?> affordanceUriVariables,
-    Map<String, Object?> uriVariables,
-  ) {
-    final missingTdDefinitions =
-        hrefUriVariables.where((element) => !uriVariables.containsKey(element));
-
-    if (missingTdDefinitions.isNotEmpty) {
-      throw UriVariableException(
-        "$missingTdDefinitions do not have defined "
-        "uriVariables in the TD",
-      );
-    }
-
-    final missingUserInput = hrefUriVariables
-        .where((element) => !affordanceUriVariables.containsKey(element));
-
-    if (missingUserInput.isNotEmpty) {
-      throw UriVariableException(
-        "$missingUserInput did not have defined "
-        "Values in the provided InteractionOptions.",
-      );
-    }
-
-    // We now assert that all user provided values comply to the Schema
-    // definition in the TD.
-    for (final affordanceUriVariable in affordanceUriVariables.entries) {
-      final key = affordanceUriVariable.key;
-      final value = affordanceUriVariable.value;
-
-      if (value == null) {
-        throw ValidationException("Missing schema for URI variable $key");
-      }
-
-      final schema = JsonSchema.create(value);
-      final result = schema.validate(uriVariables[key]);
-
-      if (!result.isValid) {
-        throw ValidationException("Invalid type for URI variable $key");
-      }
-    }
-  }
-
-  List<String> _filterUriVariables(Uri href) {
-    final regex = RegExp("{[?+#./;&]?([^}]*)}");
-    final decodedUri = Uri.decodeFull(href.toString());
-    return regex
-        .allMatches(decodedUri)
-        .map((e) => e.group(1))
-        .whereType<String>()
-        .toList(growable: false);
-  }
-
-  /// Resolves all [uriVariables] in this [Form] and creates a copy with an
-  /// updated [resolvedHref].
-  ///
-  /// Returns [Null] if the [href] field does not use any URI variables.
-  Form? resolveUriVariables(Map<String, Object>? uriVariables) {
-    final hrefUriVariables = _filterUriVariables(resolvedHref);
-
-    // Use global URI variables by default and override them with
-    // affordance-level variables, if any
-    final Map<String, Object?> affordanceUriVariables = {}
-      ..addAll(thingDescription.uriVariables ?? {})
-      ..addAll(interactionAffordance?.uriVariables ?? {});
-
-    if (hrefUriVariables.isEmpty) {
-      // The href uses no uriVariables, therefore we can abort all further
-      // checks.
-      return null;
-    }
-
-    if (uriVariables != null) {
-      // Perform additional validation
-      _validateUriVariables(
-        hrefUriVariables,
-        affordanceUriVariables,
-        uriVariables,
-      );
-    }
-
-    // As "{" and "}" are "percent encoded" due to Uri.parse(), we need to
-    // revert the encoding first before we can insert the values.
-    final decodedHref = Uri.decodeFull(href.toString());
-
-    // Everything should be okay at this point, we can simply insert the values
-    // and return the result.
-    final newHref =
-        Uri.parse(UriTemplate(decodedHref).expand(uriVariables ?? {}));
-    return _copy(newHref);
-  }
-}
-
-/// This [Exception] is thrown when [URI variables] are being used in the [Form]
-/// of a TD but no (valid) values were provided.
-///
-/// [URI variables]: https://www.w3.org/TR/wot-thing-description11/#form-uriVariables
-class UriVariableException implements Exception {
-  /// Constructor.
-  UriVariableException(this.message);
-
-  /// The error [message].
-  final String message;
-
-  @override
-  String toString() {
-    return "UriVariableException: $message";
-  }
 }

--- a/lib/src/definitions/interaction_affordances/action.dart
+++ b/lib/src/definitions/interaction_affordances/action.dart
@@ -4,26 +4,20 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "package:curie/curie.dart";
-import "package:meta/meta.dart";
-
-import "../data_schema.dart";
-import "../extensions/json_parser.dart";
-import "../thing_description.dart";
-import "interaction_affordance.dart";
+part of "interaction_affordance.dart";
 
 /// Class representing an [Action] Affordance in a Thing Description.
 @immutable
-class Action extends InteractionAffordance {
+final class Action extends InteractionAffordance {
   /// Creates a new [Action] from a [List] of [forms].
-  Action(
-    super.thingDescription, {
+  const Action({
+    required super.forms,
     super.title,
     super.titles,
     super.description,
     super.descriptions,
     super.uriVariables,
-    super.forms,
+    super.additionalFields,
     this.safe = false,
     this.idempotent = false,
     this.synchronous,
@@ -34,7 +28,6 @@ class Action extends InteractionAffordance {
   /// Creates a new [Action] from a [json] object.
   factory Action.fromJson(
     Map<String, dynamic> json,
-    ThingDescription thingDescription,
     PrefixMapping prefixMapping,
   ) {
     final Set<String> parsedFields = {};
@@ -45,7 +38,7 @@ class Action extends InteractionAffordance {
     final descriptions =
         json.parseMapField<String>("descriptions", parsedFields);
     final uriVariables =
-        json.parseMapField<dynamic>("uriVariables", parsedFields);
+        json.parseMapField<Object>("uriVariables", parsedFields);
 
     final safe = json.parseField<bool>("safe", parsedFields) ?? false;
     final idempotent =
@@ -56,8 +49,12 @@ class Action extends InteractionAffordance {
     final output =
         json.parseDataSchemaField("output", prefixMapping, parsedFields);
 
+    final forms = json.parseAffordanceForms(prefixMapping, parsedFields);
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
     final action = Action(
-      thingDescription,
+      forms: forms,
       title: title,
       titles: titles,
       description: description,
@@ -68,12 +65,8 @@ class Action extends InteractionAffordance {
       synchronous: synchronous,
       input: input,
       output: output,
+      additionalFields: additionalFields,
     );
-
-    action.forms
-        .addAll(json.parseAffordanceForms(action, prefixMapping, parsedFields));
-    action.additionalFields
-        .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
 
     return action;
   }

--- a/lib/src/definitions/interaction_affordances/event.dart
+++ b/lib/src/definitions/interaction_affordances/event.dart
@@ -4,35 +4,27 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "package:curie/curie.dart";
-import "package:meta/meta.dart";
-
-import "../data_schema.dart";
-import "../extensions/json_parser.dart";
-import "../thing_description.dart";
-import "interaction_affordance.dart";
+part of "interaction_affordance.dart";
 
 /// Class representing an [Event] Affordance in a Thing Description.
-@immutable
 class Event extends InteractionAffordance {
   /// Creates a new [Event] from a [List] of [forms].
-  Event(
-    super.thingDescription, {
+  const Event({
     super.title,
     super.titles,
     super.description,
     super.descriptions,
     super.uriVariables,
-    super.forms,
+    required super.forms,
     this.subscription,
     this.data,
     this.cancellation,
+    super.additionalFields,
   });
 
   /// Creates a new [Event] from a [json] object.
   factory Event.fromJson(
     Map<String, dynamic> json,
-    ThingDescription thingDescription,
     PrefixMapping prefixMapping,
   ) {
     final Set<String> parsedFields = {};
@@ -43,7 +35,7 @@ class Event extends InteractionAffordance {
     final descriptions =
         json.parseMapField<String>("descriptions", parsedFields);
     final uriVariables =
-        json.parseMapField<dynamic>("uriVariables", parsedFields);
+        json.parseMapField<Object>("uriVariables", parsedFields);
 
     final subscription =
         json.parseDataSchemaField("subscription", prefixMapping, parsedFields);
@@ -51,8 +43,12 @@ class Event extends InteractionAffordance {
     final cancellation =
         json.parseDataSchemaField("cancellation", prefixMapping, parsedFields);
 
+    final forms = json.parseAffordanceForms(prefixMapping, parsedFields);
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
     final event = Event(
-      thingDescription,
+      forms: forms,
       title: title,
       titles: titles,
       description: description,
@@ -61,12 +57,7 @@ class Event extends InteractionAffordance {
       subscription: subscription,
       data: data,
       cancellation: cancellation,
-    );
-
-    event.forms
-        .addAll(json.parseAffordanceForms(event, prefixMapping, parsedFields));
-    event.additionalFields.addAll(
-      json.parseAdditionalFields(prefixMapping, parsedFields),
+      additionalFields: additionalFields,
     );
 
     return event;

--- a/lib/src/definitions/interaction_affordances/interaction_affordance.dart
+++ b/lib/src/definitions/interaction_affordances/interaction_affordance.dart
@@ -4,32 +4,34 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+/// Sub-library for defining the three kinds of interaction affordances
+/// (properties, actions, events).
+library interaction_affordance;
+
+import "package:curie/curie.dart";
 import "package:meta/meta.dart";
 
+import "../data_schema.dart";
+import "../extensions/json_parser.dart";
 import "../form.dart";
-import "../thing_description.dart";
+
+part "action.dart";
+part "property.dart";
+part "event.dart";
 
 /// Base class for Interaction Affordances (Properties, Actions, and Events).
 @immutable
-abstract class InteractionAffordance {
-  // TODO(JKRhb): Make fields final
-
+sealed class InteractionAffordance {
   /// Creates a new [InteractionAffordance]. Accepts a [List] of [forms].
-  InteractionAffordance(
-    this.thingDescription, {
+  const InteractionAffordance({
     this.title,
     this.titles,
     this.description,
     this.descriptions,
     this.uriVariables,
-    List<Form>? forms,
-  }) {
-    this.forms.addAll(forms ?? []);
-  }
-
-  /// Reference to the [ThingDescription] containing this
-  /// [InteractionAffordance].
-  final ThingDescription thingDescription;
+    required this.forms,
+    this.additionalFields,
+  });
 
   /// The default [title] of this [InteractionAffordance].
   final String? title;
@@ -44,13 +46,13 @@ abstract class InteractionAffordance {
   final Map<String, String>? descriptions;
 
   /// The basic [forms] which can be used for interacting with this resource.
-  final List<Form> forms = [];
+  final List<Form> forms;
 
   /// URI template variables as defined in [RFC 6570].
   ///
   /// [RFC 6570]: http://tools.ietf.org/html/rfc6570
-  final Map<String, Object?>? uriVariables;
+  final Map<String, Object>? uriVariables;
 
   /// Additional fields that could not be deserialized as class members.
-  final Map<String, dynamic> additionalFields = {};
+  final Map<String, dynamic>? additionalFields;
 }

--- a/lib/src/definitions/interaction_affordances/property.dart
+++ b/lib/src/definitions/interaction_affordances/property.dart
@@ -4,22 +4,16 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "package:curie/curie.dart";
-import "package:meta/meta.dart";
-
-import "../data_schema.dart";
-import "../extensions/json_parser.dart";
-import "../thing_description.dart";
-import "interaction_affordance.dart";
+part of "interaction_affordance.dart";
 
 /// Class representing a [Property] Affordance in a Thing Description.
 @immutable
 class Property extends InteractionAffordance implements DataSchema {
   /// Default constructor that creates a [Property] from a [List] of [forms].
-  Property(
-    super.thingDescription, {
-    super.forms,
+  const Property({
+    required super.forms,
     super.uriVariables,
+    super.additionalFields,
     this.dataSchema,
     this.observable = false,
   });
@@ -27,32 +21,28 @@ class Property extends InteractionAffordance implements DataSchema {
   /// Creates a new [Property] from a [json] object.
   factory Property.fromJson(
     Map<String, dynamic> json,
-    ThingDescription thingDescription,
     PrefixMapping prefixMapping,
   ) {
     final Set<String> parsedFields = {};
     final observable =
         json.parseField<bool>("observable", parsedFields) ?? false;
     final uriVariables =
-        json.parseMapField<dynamic>("uriVariables", parsedFields);
+        json.parseMapField<Object>("uriVariables", parsedFields);
     final dataSchema = DataSchema.fromJson(json, prefixMapping, parsedFields);
+    final forms = json.parseAffordanceForms(
+      prefixMapping,
+      parsedFields,
+    );
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
 
     final property = Property(
-      thingDescription,
+      forms: forms,
       observable: observable,
       dataSchema: dataSchema,
       uriVariables: uriVariables,
-    );
-
-    property.forms.addAll(
-      json.parseAffordanceForms(
-        property,
-        prefixMapping,
-        parsedFields,
-      ),
-    );
-    property.additionalFields.addAll(
-      json.parseAdditionalFields(prefixMapping, parsedFields),
+      additionalFields: additionalFields,
     );
 
     return property;

--- a/lib/src/definitions/link.dart
+++ b/lib/src/definitions/link.dart
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import "package:curie/curie.dart";
+import "package:meta/meta.dart";
 
 import "extensions/json_parser.dart";
 
@@ -13,66 +14,73 @@ import "extensions/json_parser.dart";
 /// A link can be viewed as a statement of the form "link context has a relation
 /// type resource at link target", where the optional target attributes may
 /// further describe the resource.
+@immutable
 class Link {
   /// Constructor.
-  Link(
-    String href, {
+  const Link(
+    this.href, {
     this.type,
     this.rel,
-    String? anchor,
+    this.anchor,
     this.sizes,
     this.hreflang,
-    Map<String, dynamic>? additionalFields,
-  })  : href = Uri.parse(href),
-        anchor = anchor != null ? Uri.parse(anchor) : null {
-    if (additionalFields != null) {
-      this.additionalFields.addAll(additionalFields);
-    }
-  }
+    this.additionalFields,
+  });
 
   /// Creates a new [Link] from a [json] object.
-  Link.fromJson(Map<String, dynamic> json, PrefixMapping prefixMapping) {
+  factory Link.fromJson(
+    Map<String, dynamic> json,
+    PrefixMapping prefixMapping,
+  ) {
     final Set<String> parsedFields = {};
 
-    href = json.parseRequiredUriField("href", parsedFields);
-    type = json.parseField<String>("@type", parsedFields);
-    rel = json.parseField<String>("rel", parsedFields);
-    anchor =
-        Uri.tryParse(json.parseField<String>("anchor", parsedFields) ?? "");
-    sizes = json.parseField<String>("sizes", parsedFields);
-    hreflang = json.parseArrayField<String>("hreflang", parsedFields);
+    final href = json.parseRequiredUriField("href", parsedFields);
+    final type = json.parseField<String>("@type", parsedFields);
+    final rel = json.parseField<String>("rel", parsedFields);
+    final anchor = json.parseUriField("anchor", parsedFields);
+    final sizes = json.parseField<String>("sizes", parsedFields);
+    final hreflang = json.parseArrayField<String>("hreflang", parsedFields);
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
 
-    additionalFields
-        .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
+    return Link(
+      href,
+      type: type,
+      rel: rel,
+      anchor: anchor,
+      sizes: sizes,
+      hreflang: hreflang,
+      additionalFields: additionalFields,
+    );
   }
 
   /// Target IRI of a link or submission target of a form.
-  late final Uri href;
+  final Uri href;
 
   /// Target attribute providing a hint indicating what the media type (see RFC
   /// 2046) of the result of dereferencing the link should be.
-  String? type;
+  final String? type;
 
   /// A link relation type identifies the semantics of a link.
-  String? rel;
+  final String? rel;
 
   /// Overrides the link context (by default the Thing itself identified by its
   /// id) with the given URI or IRI.
-  Uri? anchor;
+  final Uri? anchor;
 
   /// Target attribute that specifies one or more sizes for a referenced icon.
   ///
   /// Only applicable for relation type "icon". The value pattern follows
   /// {Height}x{Width} (e.g., "16x16", "16x16 32x32").
-  String? sizes;
+  final String? sizes;
 
   /// The hreflang attribute specifies the language of a linked document.
   ///
   /// The value of this must be a valid language tag [BCP47][BCP47 link].
   ///
   /// [BCP47 link]: https://tools.ietf.org/search/bcp47
-  List<String>? hreflang;
+  final List<String>? hreflang;
 
   /// Additional fields collected during the parsing of a JSON object.
-  final Map<String, dynamic> additionalFields = <String, dynamic>{};
+  final Map<String, dynamic>? additionalFields;
 }

--- a/lib/src/definitions/operation_type.dart
+++ b/lib/src/definitions/operation_type.dart
@@ -4,6 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import "interaction_affordances/interaction_affordance.dart";
 import "validation/validation_exception.dart";
 
 /// Enumeration for the possible WoT operation types.
@@ -60,5 +61,23 @@ enum OperationType {
     }
 
     return operationType;
+  }
+
+  /// Returns the default operation types for the given [interactionAffordance].
+  static List<OperationType> defaultOpValues(
+    InteractionAffordance interactionAffordance,
+  ) {
+    switch (interactionAffordance) {
+      case Property(readOnly: final readOnly, writeOnly: final writeOnly):
+        return [
+          if (!readOnly) OperationType.writeproperty,
+          if (!writeOnly) OperationType.readproperty,
+        ];
+      case Event():
+        return [OperationType.subscribeevent, OperationType.unsubscribeevent];
+
+      case Action():
+        return [OperationType.invokeaction];
+    }
   }
 }

--- a/lib/src/definitions/security/ace_security_scheme.dart
+++ b/lib/src/definitions/security/ace_security_scheme.dart
@@ -10,12 +10,13 @@ import "../extensions/json_parser.dart";
 
 import "security_scheme.dart";
 
-const _schemeName = "ace:ACESecurityScheme";
+/// Indicates the `scheme` value for identifying [AceSecurityScheme]s.
+const aceSecuritySchemeName = "ace:ACESecurityScheme";
 
 /// Experimental ACE Security Scheme.
 final class AceSecurityScheme extends SecurityScheme {
   /// Constructor.
-  AceSecurityScheme({
+  const AceSecurityScheme({
     this.as,
     this.audience,
     this.scopes,
@@ -25,23 +26,43 @@ final class AceSecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates an [AceSecurityScheme] from a [json] object.
-  AceSecurityScheme.fromJson(
+  factory AceSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : as = json.parseField<String>("ace:as", parsedFields),
-        cnonce = json.parseField<bool>("ace:cnonce", parsedFields),
-        audience = json.parseField<String>("ace:audience", parsedFields),
-        scopes = json.parseArrayField<String>("ace:scopes", parsedFields),
-        super.fromJson(
-          _schemeName,
-          json,
-          prefixMapping,
-          parsedFields,
-        );
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final as = json.parseField<String>("ace:as", parsedFields);
+    final cnonce = json.parseField<bool>("ace:cnonce", parsedFields);
+    final audience = json.parseField<String>("ace:audience", parsedFields);
+    final scopes = json.parseArrayField<String>("ace:scopes", parsedFields);
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return AceSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      as: as,
+      cnonce: cnonce,
+      audience: audience,
+      scopes: scopes,
+      additionalFields: additionalFields,
+    );
+  }
+
+  @override
+  String get scheme => aceSecuritySchemeName;
 
   /// URI of the authorization server.
   final String? as;

--- a/lib/src/definitions/security/apikey_security_scheme.dart
+++ b/lib/src/definitions/security/apikey_security_scheme.dart
@@ -10,13 +10,15 @@ import "../extensions/json_parser.dart";
 import "security_scheme.dart";
 
 const _defaultInValue = "query";
-const _schemeName = "apikey";
+
+/// Indicates the `scheme` value for identifying [ApiKeySecurityScheme]s.
+const apiKeySecuritySchemeName = "apikey";
 
 /// API key authentication security configuration identified by the Vocabulary
 /// Term `apikey`.
 final class ApiKeySecurityScheme extends SecurityScheme {
   /// Constructor.
-  ApiKeySecurityScheme({
+  const ApiKeySecurityScheme({
     this.name,
     this.in_ = _defaultInValue,
     super.description,
@@ -24,26 +26,43 @@ final class ApiKeySecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates a [ApiKeySecurityScheme] from a [json] object.
-
-  ApiKeySecurityScheme.fromJson(
+  factory ApiKeySecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>("name", parsedFields),
-        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
-        super.fromJson(
-          _schemeName,
-          json,
-          prefixMapping,
-          parsedFields,
-        );
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final name = json.parseField<String>("name", parsedFields);
+    final in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue;
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return ApiKeySecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      name: name,
+      in_: in_,
+      additionalFields: additionalFields,
+    );
+  }
 
   /// Name for query, header, cookie, or uri parameters.
-  String? name;
+  final String? name;
 
   /// Specifies the location of security authentication information.
   final String in_;
+
+  @override
+  String get scheme => apiKeySecuritySchemeName;
 }

--- a/lib/src/definitions/security/auto_security_scheme.dart
+++ b/lib/src/definitions/security/auto_security_scheme.dart
@@ -6,26 +6,48 @@
 
 import "package:curie/curie.dart";
 
+import "../extensions/json_parser.dart";
 import "security_scheme.dart";
 
-const _schemeName = "auto";
+/// Indicates the `scheme` value for identifying [AutoSecurityScheme]s.
+const autoSecuritySchemeName = "auto";
 
 /// An automatic security configuration identified by the
 /// vocabulary term `auto`.
 final class AutoSecurityScheme extends SecurityScheme {
   /// Constructor.
-  AutoSecurityScheme({
+  const AutoSecurityScheme({
     super.description,
     super.descriptions,
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates an [AutoSecurityScheme] from a [json] object.
-  AutoSecurityScheme.fromJson(
+  factory AutoSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  ) : super.fromJson(_schemeName, json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return AutoSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      additionalFields: additionalFields,
+    );
+  }
+
+  @override
+  String get scheme => autoSecuritySchemeName;
 }

--- a/lib/src/definitions/security/basic_security_scheme.dart
+++ b/lib/src/definitions/security/basic_security_scheme.dart
@@ -11,13 +11,14 @@ import "security_scheme.dart";
 
 const _defaultInValue = "header";
 
-const _schemeName = "basic";
+/// Indicates the `scheme` value for identifying [BasicSecurityScheme]s.
+const basicSecuritySchemeName = "basic";
 
 /// Basic Authentication security configuration identified by the Vocabulary
 /// Term `basic`.
 final class BasicSecurityScheme extends SecurityScheme {
   /// Constructor.
-  BasicSecurityScheme({
+  const BasicSecurityScheme({
     this.name,
     this.in_ = _defaultInValue,
     super.description,
@@ -25,20 +26,43 @@ final class BasicSecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates a [BasicSecurityScheme] from a [json] object.
-  BasicSecurityScheme.fromJson(
+  factory BasicSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>("name", parsedFields),
-        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
-        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final name = json.parseField<String>("name", parsedFields);
+    final in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue;
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return BasicSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      name: name,
+      in_: in_,
+      additionalFields: additionalFields,
+    );
+  }
 
   /// Name for query, header, cookie, or uri parameters.
   final String? name;
 
   /// Specifies the location of security authentication information.
   final String in_;
+
+  @override
+  String get scheme => basicSecuritySchemeName;
 }

--- a/lib/src/definitions/security/bearer_security_scheme.dart
+++ b/lib/src/definitions/security/bearer_security_scheme.dart
@@ -13,13 +13,14 @@ const _defaultInValue = "header";
 const _defaultAlgValue = "ES256";
 const _defaultFormatValue = "jwt";
 
-const _schemeName = "bearer";
+/// Indicates the `scheme` value for identifying [BearerSecurityScheme]s.
+const bearerSecuritySchemeName = "bearer";
 
 /// Bearer Token security configuration identified by the Vocabulary Term
 /// `bearer`.
 final class BearerSecurityScheme extends SecurityScheme {
   /// Constructor.
-  BearerSecurityScheme({
+  const BearerSecurityScheme({
     this.name,
     this.alg = _defaultAlgValue,
     this.format = _defaultFormatValue,
@@ -30,20 +31,45 @@ final class BearerSecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates a [BearerSecurityScheme] from a [json] object.
-  BearerSecurityScheme.fromJson(
+  factory BearerSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>("name", parsedFields),
-        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
-        format = json.parseField<String>("format", parsedFields) ??
-            _defaultFormatValue,
-        alg = json.parseField<String>("alg", parsedFields) ?? _defaultAlgValue,
-        authorization = json.parseField<String>("authorization", parsedFields),
-        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final name = json.parseField<String>("name", parsedFields);
+    final in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue;
+    final format =
+        json.parseField<String>("format", parsedFields) ?? _defaultFormatValue;
+    final alg =
+        json.parseField<String>("alg", parsedFields) ?? _defaultAlgValue;
+    final authorization =
+        json.parseField<String>("authorization", parsedFields);
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return BearerSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      name: name,
+      in_: in_,
+      format: format,
+      alg: alg,
+      authorization: authorization,
+      additionalFields: additionalFields,
+    );
+  }
 
   /// URI of the authorization server.
   final String? authorization;
@@ -59,4 +85,7 @@ final class BearerSecurityScheme extends SecurityScheme {
 
   /// Specifies the location of security authentication information.
   final String in_;
+
+  @override
+  String get scheme => bearerSecuritySchemeName;
 }

--- a/lib/src/definitions/security/combo_security_scheme.dart
+++ b/lib/src/definitions/security/combo_security_scheme.dart
@@ -9,13 +9,14 @@ import "package:curie/curie.dart";
 import "../extensions/json_parser.dart";
 import "security_scheme.dart";
 
-const _schemeName = "combo";
+/// Indicates the `scheme` value for identifying [ComboSecurityScheme]s.
+const comboSecuritySchemeName = "combo";
 
 /// A combination of other security schemes identified by the Vocabulary Term
 /// `combo` (i.e., "scheme": "combo").
 final class ComboSecurityScheme extends SecurityScheme {
   /// Constructor.
-  ComboSecurityScheme({
+  const ComboSecurityScheme({
     this.allOf,
     this.oneOf,
     super.description,
@@ -23,16 +24,36 @@ final class ComboSecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates a [ComboSecurityScheme] from a [json] object.
-  ComboSecurityScheme.fromJson(
+  factory ComboSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : oneOf = json.parseArrayField<String>("oneOf", parsedFields),
-        allOf = json.parseArrayField<String>("allOf", parsedFields),
-        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final oneOf = json.parseArrayField<String>("oneOf", parsedFields);
+    final allOf = json.parseArrayField<String>("allOf", parsedFields);
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return ComboSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      oneOf: oneOf,
+      allOf: allOf,
+      additionalFields: additionalFields,
+    );
+  }
 
   /// Array of two or more strings identifying other named security scheme
   /// definitions, any one of which, when satisfied, will allow access.
@@ -43,4 +64,7 @@ final class ComboSecurityScheme extends SecurityScheme {
   /// Array of two or more strings identifying other named security scheme
   /// definitions, all of which must be satisfied for access.
   final List<String>? allOf;
+
+  @override
+  String get scheme => comboSecuritySchemeName;
 }

--- a/lib/src/definitions/security/digest_security_scheme.dart
+++ b/lib/src/definitions/security/digest_security_scheme.dart
@@ -9,6 +9,9 @@ import "package:curie/curie.dart";
 import "../extensions/json_parser.dart";
 import "security_scheme.dart";
 
+/// Indicates the `scheme` value for identifying [DigestSecurityScheme]s.
+const digestSecuritySchemeName = "digest";
+
 const _defaultInValue = "header";
 
 const _defaultQoPValue = "auth";
@@ -17,7 +20,7 @@ const _defaultQoPValue = "auth";
 /// Vocabulary Term `digest`.
 final class DigestSecurityScheme extends SecurityScheme {
   /// Constructor.
-  DigestSecurityScheme({
+  const DigestSecurityScheme({
     this.in_ = _defaultInValue,
     this.qop = _defaultQoPValue,
     this.name,
@@ -26,17 +29,39 @@ final class DigestSecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super("digest");
+  });
 
   /// Creates a [DigestSecurityScheme] from a [json] object.
-  DigestSecurityScheme.fromJson(
+  factory DigestSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>("name", parsedFields),
-        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
-        qop = json.parseField<String>("qop", parsedFields) ?? _defaultInValue,
-        super.fromJson("digest", json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final name = json.parseField<String>("name", parsedFields);
+    final in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue;
+    final qop =
+        json.parseField<String>("qop", parsedFields) ?? _defaultQoPValue;
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return DigestSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      name: name,
+      qop: qop,
+      in_: in_,
+      additionalFields: additionalFields,
+    );
+  }
 
   /// Name for query, header, cookie, or uri parameters.
   final String? name;
@@ -46,4 +71,7 @@ final class DigestSecurityScheme extends SecurityScheme {
 
   /// Quality of protection.
   final String qop;
+
+  @override
+  String get scheme => digestSecuritySchemeName;
 }

--- a/lib/src/definitions/security/no_security_scheme.dart
+++ b/lib/src/definitions/security/no_security_scheme.dart
@@ -6,26 +6,48 @@
 
 import "package:curie/curie.dart";
 
+import "../extensions/json_parser.dart";
 import "security_scheme.dart";
 
-const _schemeName = "nosec";
+/// Indicates the `scheme` value for identifying [NoSecurityScheme]s.
+const nosecSecuritySchemeName = "nosec";
 
 /// A security configuration corresponding to identified by the Vocabulary Term
 /// `nosec`.
 final class NoSecurityScheme extends SecurityScheme {
   /// Constructor.
-  NoSecurityScheme({
+  const NoSecurityScheme({
     super.description,
     super.descriptions,
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates a [NoSecurityScheme] from a [json] object.
-  NoSecurityScheme.fromJson(
+  factory NoSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  ) : super.fromJson(_schemeName, json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return NoSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      additionalFields: additionalFields,
+    );
+  }
+
+  @override
+  String get scheme => nosecSecuritySchemeName;
 }

--- a/lib/src/definitions/security/oauth2_security_scheme.dart
+++ b/lib/src/definitions/security/oauth2_security_scheme.dart
@@ -9,14 +9,15 @@ import "package:curie/curie.dart";
 import "../extensions/json_parser.dart";
 import "security_scheme.dart";
 
-const _schemeName = "oauth2";
+/// Indicates the `scheme` value for identifying [OAuth2SecurityScheme]s.
+const oAuth2SecuritySchemeName = "oauth2";
 
 /// OAuth 2.0 authentication security configuration for systems conformant with
 /// RFC 6749, RFC 8252 and (for the device flow) RFC 8628, identified by the
 /// Vocabulary Term `oauth2`.
 final class OAuth2SecurityScheme extends SecurityScheme {
   /// Constructor.
-  OAuth2SecurityScheme(
+  const OAuth2SecurityScheme(
     this.flow, {
     this.authorization,
     this.scopes,
@@ -27,19 +28,43 @@ final class OAuth2SecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates a [OAuth2SecurityScheme] from a [json] object.
-  OAuth2SecurityScheme.fromJson(
+  factory OAuth2SecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : authorization = json.parseField<String>("authorization", parsedFields),
-        token = json.parseField<String>("token", parsedFields),
-        refresh = json.parseField<String>("refresh", parsedFields),
-        scopes = json.parseArrayField<String>("scopes", parsedFields),
-        flow = json.parseRequiredField<String>("flow", parsedFields),
-        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final authorization =
+        json.parseField<String>("authorization", parsedFields);
+    final token = json.parseField<String>("token", parsedFields);
+    final refresh = json.parseField<String>("refresh", parsedFields);
+    final scopes = json.parseArrayField<String>("scopes", parsedFields);
+    final flow = json.parseRequiredField<String>("flow", parsedFields);
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return OAuth2SecurityScheme(
+      flow,
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      authorization: authorization,
+      token: token,
+      refresh: refresh,
+      scopes: scopes,
+      additionalFields: additionalFields,
+    );
+  }
 
   /// URI of the authorization server.
   ///
@@ -63,4 +88,7 @@ final class OAuth2SecurityScheme extends SecurityScheme {
 
   /// Authorization flow.
   final String flow;
+
+  @override
+  String get scheme => oAuth2SecuritySchemeName;
 }

--- a/lib/src/definitions/security/psk_security_scheme.dart
+++ b/lib/src/definitions/security/psk_security_scheme.dart
@@ -9,29 +9,52 @@ import "package:curie/curie.dart";
 import "../extensions/json_parser.dart";
 import "security_scheme.dart";
 
-const _schemeName = "psk";
+/// Indicates the `scheme` value for identifying [PskSecurityScheme]s.
+const pskSecuritySchemeName = "psk";
 
 /// Pre-shared key authentication security configuration identified by the
 /// Vocabulary Term `psk`.
 final class PskSecurityScheme extends SecurityScheme {
   /// Constructor.
-  PskSecurityScheme({
+  const PskSecurityScheme({
     this.identity,
     super.description,
     super.descriptions,
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super(_schemeName);
+  });
 
   /// Creates a [PskSecurityScheme] from a [json] object.
-  PskSecurityScheme.fromJson(
+  factory PskSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : identity = json.parseField<String>("identity"),
-        super.fromJson(_schemeName, json, prefixMapping, parsedFields);
+  ) {
+    final description = json.parseField<String>("description", parsedFields);
+    final descriptions =
+        json.parseMapField<String>("descriptions", parsedFields);
+    final jsonLdType = json.parseArrayField<String>("@type");
+    final proxy = json.parseUriField("proxy", parsedFields);
+
+    final identity = json.parseField<String>("identity");
+
+    final additionalFields =
+        json.parseAdditionalFields(prefixMapping, parsedFields);
+
+    return PskSecurityScheme(
+      description: description,
+      descriptions: descriptions,
+      jsonLdType: jsonLdType,
+      proxy: proxy,
+      identity: identity,
+      additionalFields: additionalFields,
+    );
+  }
 
   /// Name for query, header, cookie, or uri parameters.
   final String? identity;
+
+  @override
+  String get scheme => pskSecuritySchemeName;
 }

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -4,16 +4,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "package:curie/curie.dart";
-
-import "../extensions/json_parser.dart";
+import "package:meta/meta.dart";
 
 /// Class that contains metadata describing the configuration of a security
 /// mechanism.
-base class SecurityScheme {
+@immutable
+abstract base class SecurityScheme {
   /// Constructor.
-  SecurityScheme(
-    this.scheme, {
+  const SecurityScheme({
     this.jsonLdType,
     this.description,
     this.proxy,
@@ -21,24 +19,11 @@ base class SecurityScheme {
     this.additionalFields,
   });
 
-  /// Creates a [SecurityScheme] from a [json] object.
-  SecurityScheme.fromJson(
-    this.scheme,
-    Map<String, dynamic> json,
-    PrefixMapping prefixMapping,
-    Set<String> parsedFields,
-  )   : proxy = json.parseUriField("proxy", parsedFields),
-        description = json.parseField<String>("description", parsedFields),
-        descriptions = json.parseMapField<String>("descriptions", parsedFields),
-        jsonLdType = json.parseArrayField<String>("@type"),
-        additionalFields =
-            json.parseAdditionalFields(prefixMapping, parsedFields);
-
   /// The actual security [scheme] identifier.
   ///
   /// Can be one of `nosec`, `combo`, `basic`, `digest`, `bearer`, `psk`,
   /// `oauth2`, or `apikey`.
-  final String scheme;
+  String get scheme;
 
   /// The default [description] of this [SecurityScheme].
   final String? description;

--- a/lib/src/definitions/thing_description.dart
+++ b/lib/src/definitions/thing_description.dart
@@ -252,3 +252,11 @@ class ThingDescription {
     return id ?? base?.toString() ?? title;
   }
 }
+
+/// Extension for generating [ThingDescription]s from [Map]s more easily.
+extension ToThingDescription on Map<String, dynamic> {
+  /// Tries to generate a [ThingDescription] from this [Map] object.
+  ThingDescription toThingDescription() {
+    return ThingDescription.fromJson(this);
+  }
+}

--- a/lib/src/definitions/thing_model.dart
+++ b/lib/src/definitions/thing_model.dart
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "thing_description.dart";
+import "extensions/json_parser.dart";
 
 /// Class representing a WoT Thing Model.
 ///
@@ -12,8 +12,32 @@ import "thing_description.dart";
 ///
 /// [spec link]: https://w3c.github.io/wot-thing-description/#thing-model
 class ThingModel {
-  /// Converts this [ThingModel] to a [ThingDescription].
-  ThingDescription toThingDescription() {
-    return ThingDescription.fromThingModel(this);
+  /// Creates a new Thing Model instance.
+  ThingModel({
+    this.title,
+    this.id,
+  });
+
+  /// Creates a new [ThingModel] from a [json] object.
+  factory ThingModel.fromJson(
+    Map<String, dynamic> json, {
+    // ignore: avoid_unused_constructor_parameters
+    bool validate = true,
+  }) {
+    final Set<String> parsedFields = {};
+
+    final title = json.parseField<String>("title", parsedFields);
+    final id = json.parseField<String>("id", parsedFields);
+
+    return ThingModel(
+      title: title,
+      id: id,
+    );
   }
+
+  /// The [title] of this [ThingModel].
+  final String? title;
+
+  /// The [id] of this [ThingModel]. Might be `null`.
+  final String? id;
 }

--- a/lib/src/scripting_api/subscription.dart
+++ b/lib/src/scripting_api/subscription.dart
@@ -4,8 +4,6 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "../definitions/form.dart";
-import "../definitions/interaction_affordances/interaction_affordance.dart";
 import "../definitions/operation_type.dart";
 
 /// [Exception] that is thrown when error during the unsubscribe process occurs.
@@ -55,69 +53,4 @@ abstract interface class Subscription {
     Map<String, Object>? uriVariables,
     Object? data,
   });
-}
-
-/// Finds a matching unsubscribe [Form] for a subscription [form].
-///
-/// Uses either a dedicated [formIndex] or determines the [Form] using
-/// the [interaction] Affordance and the [type] of subscription it belongs to.
-// TODO(JKRhb): Using an index does not seem the best idea to me.
-Form findUnsubscribeForm(
-  InteractionAffordance interaction,
-  SubscriptionType type,
-  Form form,
-  int? formIndex,
-) {
-  if (formIndex != null) {
-    return interaction.forms[formIndex];
-  }
-
-  final operationType = type.operationType;
-  final formOperations = form.op;
-
-  // The default op value also contains the unsubscribe/unobserve operation.
-  if (formOperations.contains(operationType)) {
-    return form;
-  }
-
-  final unsubscribeForm = _findFormByScoring(interaction, form, operationType);
-
-  if (unsubscribeForm == null) {
-    throw UnsubscribeException("Could not find matching form for unsubscribe");
-  }
-
-  return unsubscribeForm;
-}
-
-Form? _findFormByScoring(
-  InteractionAffordance interaction,
-  Form form,
-  OperationType operationType,
-) {
-  int maxScore = 0;
-  Form? foundForm;
-
-  for (final Form currentForm in interaction.forms) {
-    int score;
-    if (form.op.contains(operationType)) {
-      score = 1;
-    } else {
-      continue;
-    }
-
-    if (form.resolvedHref.origin == currentForm.resolvedHref.origin) {
-      score++;
-    }
-
-    if (form.contentType == currentForm.contentType) {
-      score++;
-    }
-
-    if (score > maxScore) {
-      maxScore = score;
-      foundForm = currentForm;
-    }
-  }
-
-  return foundForm;
 }

--- a/test/binding_coap/coap_vocabulary_test.dart
+++ b/test/binding_coap/coap_vocabulary_test.dart
@@ -55,25 +55,36 @@ void main() {
       };
 
       final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
-      final property = thingDescription.properties["status"];
-      final form = property?.forms[0];
+      final property = thingDescription.properties?["status"];
+      final form = AugmentedForm(
+        property!.forms.first,
+        property,
+        thingDescription,
+        const {},
+      );
 
-      expect(form?.href, Uri.parse("coap://example.org"));
-      expect(form?.method, CoapRequestMethod.ipatch);
-      expect(form?.contentFormat, CoapMediaType.applicationCbor);
-      expect(form?.accept, CoapMediaType.applicationCbor);
-      expect(form?.block1Size, BlockSize.blockSize32);
-      expect(form?.block2Size, BlockSize.blockSize64);
-      expect(form?.response?.contentFormat, CoapMediaType.applicationCbor);
+      expect(form.href, Uri.parse("coap://example.org"));
+      expect(form.method, CoapRequestMethod.ipatch);
+      expect(form.contentFormat, CoapMediaType.applicationCbor);
+      expect(form.accept, CoapMediaType.applicationCbor);
+      expect(form.block1Size, BlockSize.blockSize32);
+      expect(form.block2Size, BlockSize.blockSize64);
+      expect(form.response?.contentFormat, CoapMediaType.applicationCbor);
 
       // TODO(JKRhb): Validation should happen earlier
-      final invalidForm = property?.forms[1];
+
+      final invalidForm = AugmentedForm(
+        property.forms[1],
+        property,
+        thingDescription,
+        const {},
+      );
       expect(
-        () => invalidForm?.block1Size,
+        () => invalidForm.block1Size,
         throwsA(isA<ValidationException>()),
       );
       expect(
-        () => invalidForm?.block2Size,
+        () => invalidForm.block2Size,
         throwsA(isA<ValidationException>()),
       );
     });

--- a/test/binding_http/http_test.dart
+++ b/test/binding_http/http_test.dart
@@ -57,53 +57,40 @@ void main() {
         //              automatically by http_auth instead)
         const qop = "auth-int";
 
-        const thingDescriptionJson = '''
-      {
-        "@context": ["http://www.w3.org/ns/td"],
-        "title": "Test Thing",
-        "base": "https://httpbin.org",
-        "securityDefinitions": {
-          "basic_sc": {
-            "scheme": "basic"
+        const thingDescriptionJson = {
+          "@context": ["http://www.w3.org/ns/td"],
+          "title": "Test Thing",
+          "base": "https://httpbin.org",
+          "securityDefinitions": {
+            "basic_sc": {"scheme": "basic"},
+            "digest_sc": {"scheme": "digest"},
+            "bearer_sc": {"scheme": "bearer"},
           },
-          "digest_sc": {
-            "scheme": "digest"
+          "security": "basic_sc",
+          "properties": {
+            "status": {
+              "forms": [
+                {"href": "/basic-auth/$username/$password"},
+              ],
+            },
+            "status2": {
+              "forms": [
+                {
+                  "href": "/digest-auth/$qop/$username/$password",
+                  "security": "digest_sc",
+                  "qop": qop,
+                }
+              ],
+            },
+            "status3": {
+              "forms": [
+                {"href": "/bearer", "security": "bearer_sc"},
+              ],
+            },
           },
-          "bearer_sc": {
-            "scheme": "bearer"
-          }
-        },
-        "security": "basic_sc",
-        "properties": {
-          "status": {
-            "forms": [
-              {
-                "href": "/basic-auth/$username/$password"
-              }
-            ]
-          },
-          "status2": {
-            "forms": [
-              {
-                "href": "/digest-auth/$qop/$username/$password",
-                "security": "digest_sc",
-                "qop": "$qop"
-              }
-            ]
-          },
-          "status3": {
-            "forms": [
-              {
-                "href": "/bearer",
-                "security": "bearer_sc"
-              }
-            ]
-          }
-        }
-      }
-      ''';
+        };
 
-        final parsedTd = ThingDescription(thingDescriptionJson);
+        final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
 
         final Map<String, BasicCredentials> basicCredentialsStore = {
           "httpbin.org": BasicCredentials(username, password),

--- a/test/binding_mqtt/mqtt_extension_test.dart
+++ b/test/binding_mqtt/mqtt_extension_test.dart
@@ -1,0 +1,60 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/dart_wot.dart";
+import "package:dart_wot/src/binding_mqtt/mqtt_extensions.dart";
+import "package:dart_wot/src/definitions/validation/validation_exception.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("MQTT Binding Extensions should", () {
+    test("reject forms with unknown QoS values", () {
+      const id = "urn:foobar";
+      const href = "mqtt://example.org/test";
+      final thingDescription = ThingDescription.fromJson(
+        const {
+          "@context": [
+            "https://www.w3.org/2022/wot/td/v1.1",
+            {
+              "mqv": "http://www.example.org/mqtt-binding#",
+            }
+          ],
+          "title": "Test TD",
+          "id": id,
+          "properties": {
+            "test": {
+              "forms": [
+                {
+                  "href": href,
+                  "mqv:qos": "foobar",
+                }
+              ],
+            },
+          },
+          "security": ["nosec_sc"],
+          "securityDefinitions": {
+            "nosec_sc": {
+              "scheme": "nosec",
+            },
+          },
+        },
+      );
+      final affordance = thingDescription.properties?["test"];
+
+      final augmentedForm = AugmentedForm(
+        affordance!.forms.first,
+        affordance,
+        thingDescription,
+        const {},
+      );
+
+      expect(
+        () => augmentedForm.qualityOfService,
+        throwsA(isA<ValidationException>()),
+      );
+    });
+  });
+}

--- a/test/core/augmented_form_test.dart
+++ b/test/core/augmented_form_test.dart
@@ -1,0 +1,240 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/dart_wot.dart";
+import "package:dart_wot/src/definitions/security/no_security_scheme.dart";
+import "package:dart_wot/src/definitions/validation/validation_exception.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("AugmentedForm should", () {
+    test("be able to be instantiated", () {
+      const id = "urn:foobar";
+      const href = "http://example.org";
+      const href2 = "coap://example.org";
+      final thingDescription = ThingDescription.fromJson(
+        const {
+          "@context": "https://www.w3.org/2022/wot/td/v1.1",
+          "title": "Test TD",
+          "id": id,
+          "properties": {
+            "test": {
+              "forms": [
+                {
+                  "href": href,
+                  "contentCoding": "gzip",
+                  "scopes": ["hi"],
+                  "subprotocol": "Hyper Text Coffee Pot Control Protocol",
+                  "additionalResponses": [
+                    {
+                      "contentType": "application/json",
+                    },
+                  ],
+                }
+              ],
+            },
+            "test2": {
+              "forms": [
+                {
+                  "href": "/test",
+                },
+              ],
+            },
+          },
+          "base": href2,
+          "security": ["nosec_sc"],
+          "securityDefinitions": {
+            "nosec_sc": {
+              "scheme": "nosec",
+            },
+          },
+        },
+      );
+      final affordance = thingDescription.properties?["test"];
+
+      final augmentedForm = AugmentedForm(
+        affordance!.forms.first,
+        affordance,
+        thingDescription,
+        const {},
+      );
+
+      expect(augmentedForm.href, Uri.parse(href));
+      expect(augmentedForm.security, ["nosec_sc"]);
+      expect(augmentedForm.securityDefinitions.first, isA<NoSecurityScheme>());
+      expect(augmentedForm.tdIdentifier, id);
+      expect(
+        augmentedForm.additionalResponses?.first.contentType,
+        "application/json",
+      );
+      expect(augmentedForm.contentCoding, "gzip");
+      expect(augmentedForm.contentType, "application/json");
+      expect(augmentedForm.scopes, ["hi"]);
+      expect(
+        augmentedForm.subprotocol,
+        "Hyper Text Coffee Pot Control Protocol",
+      );
+
+      final affordance2 = thingDescription.properties?["test2"];
+
+      final augmentedForm2 = AugmentedForm(
+        affordance2!.forms[0],
+        affordance2,
+        thingDescription,
+        const {},
+      );
+      expect(augmentedForm2.href, Uri.parse("$href2/test"));
+    });
+
+    test("handle URI variables", () {
+      final thingDescription = ThingDescription.fromJson(
+        const {
+          "@context": "https://www.w3.org/2022/wot/td/v1.1",
+          "title": "Test TD",
+          "properties": {
+            "test": {
+              "uriVariables": {
+                "lat": {
+                  "type": "number",
+                  "minimum": 0,
+                  "maximum": 90,
+                  "description":
+                      "Latitude for the desired location in the world",
+                },
+              },
+              "forms": [
+                {
+                  "href": "http://example.org/weather/{?lat,long}",
+                },
+                {
+                  "href": "http://example.org/weather/{?foo}",
+                },
+                {
+                  "href": "http://example.org/weather",
+                },
+              ],
+            },
+          },
+          "uriVariables": {
+            "long": {
+              "type": "number",
+              "minimum": -180,
+              "maximum": 180,
+              "description": "Longitude for the desired location in the world",
+            },
+          },
+          "security": ["nosec_sc"],
+          "securityDefinitions": {
+            "nosec_sc": {
+              "scheme": "nosec",
+            },
+          },
+        },
+      );
+      final affordance = thingDescription.properties?["test"];
+
+      final augmentedForm1 = AugmentedForm(
+        affordance!.forms.first,
+        affordance,
+        thingDescription,
+        const {
+          "lat": 5,
+          "long": 10,
+        },
+      );
+
+      expect(
+        augmentedForm1.resolvedHref,
+        Uri.parse("http://example.org/weather/?lat=5&long=10"),
+      );
+
+      expect(
+        augmentedForm1.resolvedHref != augmentedForm1.href,
+        isTrue,
+      );
+
+      final augmentedForm2 = AugmentedForm(
+        affordance.forms.first,
+        affordance,
+        thingDescription,
+        const {
+          "lat": 5,
+        },
+      );
+
+      expect(
+        () => augmentedForm2.resolvedHref,
+        throwsA(isA<UriVariableException>()),
+      );
+
+      final augmentedForm3 = AugmentedForm(
+        affordance.forms.first,
+        affordance,
+        thingDescription,
+        const {
+          "long": 10,
+        },
+      );
+
+      expect(
+        () => augmentedForm3.resolvedHref,
+        throwsA(
+          predicate(
+            (exception) =>
+                exception is UriVariableException &&
+                exception.toString() ==
+                    "UriVariableException: The following URI template "
+                        "variables defined at the TD level are not covered by "
+                        "the values provided by the user: lat. Values for the "
+                        "following variables were received: long.",
+          ),
+        ),
+      );
+
+      final augmentedForm4 = AugmentedForm(
+        affordance.forms.first,
+        affordance,
+        thingDescription,
+        const {
+          "lat": "hi",
+          "long": 10,
+        },
+      );
+
+      expect(
+        () => augmentedForm4.resolvedHref,
+        throwsA(isA<ValidationException>()),
+      );
+
+      final augmentedForm5 = AugmentedForm(
+        affordance.forms[1],
+        affordance,
+        thingDescription,
+        const {
+          "lat": "hi",
+          "long": 10,
+        },
+      );
+
+      expect(
+        () => augmentedForm5.resolvedHref,
+        throwsA(isA<ValidationException>()),
+      );
+
+      final augmentedForm6 = AugmentedForm(
+        affordance.forms[2],
+        affordance,
+        thingDescription,
+        const {},
+      );
+
+      expect(
+        augmentedForm6.href,
+        augmentedForm6.resolvedHref,
+      );
+    });
+  });
+}

--- a/test/core/consumed_thing_test.dart
+++ b/test/core/consumed_thing_test.dart
@@ -18,12 +18,8 @@ import "package:dart_wot/src/definitions/validation/validation_exception.dart";
 import "package:test/test.dart";
 
 void main() {
-  group("Consumed Thing Tests", () {
-    setUp(() {
-      // Additional setup goes here.
-    });
-
-    test("Parse Interaction Affordances", () async {
+  group("ConsumedThing should", () {
+    test("parse Interaction Affordances", () async {
       const thingDescriptionJson = {
         "@context": [
           "https://www.w3.org/2022/wot/td/v1.1",
@@ -219,7 +215,7 @@ void main() {
   });
 
   test(
-    "Use of URI Template Variables",
+    "use URI Template Variables",
     () async {
       const thingDescriptionJson = {
         "@context": ["http://www.w3.org/ns/td"],
@@ -279,4 +275,50 @@ void main() {
     },
     skip: true, // TODO: Replace with test with local server
   );
+
+  test("throw ArgumentErrors for missing Affordances", () async {
+    const thingDescriptionJson = {
+      "@context": "https://www.w3.org/2022/wot/td/v1.1",
+      "title": "Test Thing",
+      "securityDefinitions": {
+        "nosec_sc": {"scheme": "nosec"},
+      },
+      "security": "nosec_sc",
+    };
+
+    final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
+
+    final servient = Servient();
+    final wot = await servient.start();
+
+    final consumedThing = await wot.consume(parsedTd);
+
+    expect(
+      () async => await consumedThing.readProperty("test"),
+      throwsArgumentError,
+    );
+
+    expect(
+      () async => await consumedThing.writeProperty(
+        "test",
+        null.asInteractionInput(),
+      ),
+      throwsArgumentError,
+    );
+
+    expect(
+      () async => await consumedThing.observeProperty("test", (_) => ()),
+      throwsArgumentError,
+    );
+
+    expect(
+      () async => await consumedThing.invokeAction("test"),
+      throwsArgumentError,
+    );
+
+    expect(
+      () async => await consumedThing.subscribeEvent("test", (_) => ()),
+      throwsArgumentError,
+    );
+  });
 }

--- a/test/core/consumed_thing_test.dart
+++ b/test/core/consumed_thing_test.dart
@@ -6,6 +6,7 @@
 
 import "package:dart_wot/dart_wot.dart";
 import "package:dart_wot/src/definitions/security/apikey_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/auto_security_scheme.dart";
 import "package:dart_wot/src/definitions/security/basic_security_scheme.dart";
 import "package:dart_wot/src/definitions/security/bearer_security_scheme.dart";
 import "package:dart_wot/src/definitions/security/combo_security_scheme.dart";
@@ -23,47 +24,29 @@ void main() {
     });
 
     test("Parse Interaction Affordances", () async {
-      const thingDescriptionJson = '''
-      {
+      const thingDescriptionJson = {
         "@context": [
-          "http://www.w3.org/ns/td",
-          {
-            "coap": "http://www.example.org/coap-binding#"
-          }
+          "https://www.w3.org/2022/wot/td/v1.1",
+          {"coap": "http://www.example.org/coap-binding#"},
         ],
         "title": "Test Thing",
-        "titles": {
-          "en": "Test Thing"
-        },
+        "titles": {"en": "Test Thing"},
         "description": "A Test Thing used for Testing.",
-        "descriptions": {
-          "en": "A Test Thing used for Testing."
-        },
+        "descriptions": {"en": "A Test Thing used for Testing."},
         "securityDefinitions": {
           "nosec_sc": {
             "scheme": "nosec",
             "proxy": "http://example.org",
-            "@type": "Test"
+            "@type": "Test",
           },
-          "basic_sc": {
-            "scheme": "basic",
-            "in": "query",
-            "description": "Test"
-          },
-          "psk_sc": {
-            "scheme": "psk",
-            "identity": "Test"
-          },
-          "apikey_sc": {
-            "scheme": "apikey",
-            "name": "Test",
-            "in": "body"
-          },
+          "basic_sc": {"scheme": "basic", "in": "query", "description": "Test"},
+          "psk_sc": {"scheme": "psk", "identity": "Test"},
+          "apikey_sc": {"scheme": "apikey", "name": "Test", "in": "body"},
           "digest_sc": {
             "scheme": "digest",
             "name": "Test",
             "in": "cookie",
-            "qop": "auth-int"
+            "qop": "auth-int",
           },
           "bearer_sc": {
             "scheme": "bearer",
@@ -71,7 +54,7 @@ void main() {
             "name": "Test",
             "alg": "ES256",
             "format": "jws",
-            "in": "uri"
+            "in": "header",
           },
           "oauth2_sc": {
             "scheme": "oauth2",
@@ -79,73 +62,57 @@ void main() {
             "token": "http://example.org",
             "refresh": "http://example.org",
             "scopes": "test",
-            "flow": "client"
+            "flow": "client",
           },
           "combo_sc1": {
             "scheme": "combo",
-            "allOf": ["digest_sc", "apikey_sc"]
+            "allOf": ["digest_sc", "apikey_sc"],
           },
           "combo_sc2": {
             "scheme": "combo",
-            "oneOf": ["oauth2_sc", "bearer_sc"]
-          }
+            "oneOf": ["oauth2_sc", "bearer_sc"],
+          },
+          "auto_sc": {
+            "scheme": "auto",
+          },
         },
         "security": "nosec_sc",
         "properties": {
           "status": {
             "title": "Status",
-            "titles": {
-              "en": "Status"
-            },
+            "titles": {"en": "Status"},
             "description": "Status of this Lamp",
-            "descriptions": {
-              "en": "Status of this Lamp"
-            },
+            "descriptions": {"en": "Status of this Lamp"},
             "forms": [
-              {
-                "href": "coap://example.org"
-              }
-            ]
-          }
+              {"href": "coap://example.org"},
+            ],
+          },
         },
         "actions": {
           "toggle": {
             "title": "Toggle",
-            "titles": {
-              "en": "Toggle"
-            },
+            "titles": {"en": "Toggle"},
             "description": "Toggle this Lamp",
-            "descriptions": {
-              "en": "Toggle this Lamp"
-            },
+            "descriptions": {"en": "Toggle this Lamp"},
             "forms": [
-              {
-                "href": "coap://example.org"
-              }
-            ]
-          }
+              {"href": "coap://example.org"},
+            ],
+          },
         },
         "events": {
           "overheating": {
             "title": "Overheating",
-            "titles": {
-              "en": "Overheating"
-            },
+            "titles": {"en": "Overheating"},
             "description": "Overheating of this Lamp",
-            "descriptions": {
-              "en": "Overheating of this Lamp"
-            },
+            "descriptions": {"en": "Overheating of this Lamp"},
             "forms": [
-              {
-                "href": "coap://example.org"
-              }
-            ]
-          }
-        }
-      }
-      ''';
+              {"href": "coap://example.org"},
+            ],
+          },
+        },
+      };
 
-      final parsedTd = ThingDescription(thingDescriptionJson);
+      final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
 
       final security = parsedTd.security;
       expect(security, ["nosec_sc"]);
@@ -155,19 +122,19 @@ void main() {
       expect(parsedTd.description, "A Test Thing used for Testing.");
       expect(parsedTd.descriptions, {"en": "A Test Thing used for Testing."});
 
-      final statusProperty = parsedTd.properties["status"];
+      final statusProperty = parsedTd.properties?["status"];
       expect(statusProperty!.title, "Status");
       expect(statusProperty.titles!["en"], "Status");
       expect(statusProperty.description, "Status of this Lamp");
       expect(statusProperty.descriptions!["en"], "Status of this Lamp");
 
-      final toggleAction = parsedTd.actions["toggle"];
+      final toggleAction = parsedTd.actions?["toggle"];
       expect(toggleAction!.title, "Toggle");
       expect(toggleAction.titles!["en"], "Toggle");
       expect(toggleAction.description, "Toggle this Lamp");
       expect(toggleAction.descriptions!["en"], "Toggle this Lamp");
 
-      final eventAction = parsedTd.events["overheating"];
+      final eventAction = parsedTd.events?["overheating"];
       expect(eventAction!.title, "Overheating");
       expect(eventAction.titles!["en"], "Overheating");
       expect(eventAction.description, "Overheating of this Lamp");
@@ -175,39 +142,46 @@ void main() {
 
       final nosecSc = parsedTd.securityDefinitions["nosec_sc"];
       expect(nosecSc is NoSecurityScheme, true);
-      expect(nosecSc?.proxy, Uri.parse("http://example.org"));
-      expect(nosecSc?.jsonLdType, ["Test"]);
+      expect(nosecSc!.scheme, "nosec");
+      expect(nosecSc.proxy, Uri.parse("http://example.org"));
+      expect(nosecSc.jsonLdType, ["Test"]);
 
       final basicSc = parsedTd.securityDefinitions["basic_sc"];
       expect(basicSc is BasicSecurityScheme, true);
-      expect(basicSc?.description, "Test");
+      expect(basicSc!.scheme, "basic");
+      expect(basicSc.description, "Test");
       expect((basicSc as BasicSecurityScheme?)!.in_, "query");
 
       final pskSc = parsedTd.securityDefinitions["psk_sc"];
       expect(pskSc is PskSecurityScheme, true);
+      expect(pskSc!.scheme, "psk");
       expect((pskSc as PskSecurityScheme?)!.identity, "Test");
 
       final apikeySc = parsedTd.securityDefinitions["apikey_sc"];
       expect(apikeySc is ApiKeySecurityScheme, true);
       expect((apikeySc as ApiKeySecurityScheme?)!.name, "Test");
-      expect(apikeySc!.in_, "body");
+      expect(apikeySc!.scheme, "apikey");
+      expect(apikeySc.in_, "body");
 
       final digestSc = parsedTd.securityDefinitions["digest_sc"];
       expect(digestSc is DigestSecurityScheme, true);
       expect((digestSc as DigestSecurityScheme?)!.name, "Test");
-      expect(digestSc!.in_, "cookie");
+      expect(digestSc!.scheme, "digest");
+      expect(digestSc.in_, "cookie");
       expect(digestSc.qop, "auth-int");
 
       final bearerSc = parsedTd.securityDefinitions["bearer_sc"];
       expect(bearerSc is BearerSecurityScheme, true);
+
       expect(
         (bearerSc as BearerSecurityScheme?)!.authorization,
         "http://example.org",
       );
-      expect(bearerSc!.name, "Test");
+      expect(bearerSc!.scheme, "bearer");
+      expect(bearerSc.name, "Test");
       expect(bearerSc.alg, "ES256");
       expect(bearerSc.format, "jws");
-      expect(bearerSc.in_, "uri");
+      expect(bearerSc.in_, "header");
 
       final oauth2Sc = parsedTd.securityDefinitions["oauth2_sc"];
       expect(oauth2Sc is OAuth2SecurityScheme, true);
@@ -215,7 +189,8 @@ void main() {
         (oauth2Sc as OAuth2SecurityScheme?)!.authorization,
         "http://example.org",
       );
-      expect(oauth2Sc!.refresh, "http://example.org");
+      expect(oauth2Sc!.scheme, "oauth2");
+      expect(oauth2Sc.refresh, "http://example.org");
       expect(oauth2Sc.token, "http://example.org");
       expect(oauth2Sc.scopes, ["test"]);
       expect(oauth2Sc.flow, "client");
@@ -226,7 +201,8 @@ void main() {
         (comboSc1 as ComboSecurityScheme?)!.allOf,
         ["digest_sc", "apikey_sc"],
       );
-      expect(comboSc1!.oneOf, null);
+      expect(comboSc1!.scheme, "combo");
+      expect(comboSc1.oneOf, null);
 
       final comboSc2 = parsedTd.securityDefinitions["combo_sc2"];
       expect(comboSc2 is ComboSecurityScheme, true);
@@ -235,54 +211,45 @@ void main() {
         ["oauth2_sc", "bearer_sc"],
       );
       expect(comboSc2!.allOf, null);
+
+      final autoSc = parsedTd.securityDefinitions["auto_sc"];
+      expect(autoSc is AutoSecurityScheme, true);
+      expect(autoSc?.scheme, "auto");
     });
   });
 
   test(
     "Use of URI Template Variables",
     () async {
-      const thingDescriptionJson = '''
-      {
+      const thingDescriptionJson = {
         "@context": ["http://www.w3.org/ns/td"],
         "title": "Test Thing",
         "base": "https://httpbin.org",
         "securityDefinitions": {
-          "nosec_sc": {
-            "scheme": "nosec"
-          }
+          "nosec_sc": {"scheme": "nosec"},
         },
         "security": "nosec_sc",
         "uriVariables": {
-          "value": {
-            "type": "string"
-          }
+          "value": {"type": "string"},
         },
         "properties": {
           "status": {
             "forms": [
-              {
-                "href": "/base64/{value}",
-                "contentType": "text/html"
-              }
-            ]
+              {"href": "/base64/{value}", "contentType": "text/html"},
+            ],
           },
           "status2": {
             "uriVariables": {
-              "value": {
-                "type": "integer"
-              }
+              "value": {"type": "integer"},
             },
             "forms": [
-              {
-                "href": "/base64/{value}"
-              }
-            ]
-          }
-        }
-      }
-      ''';
+              {"href": "/base64/{value}"},
+            ],
+          },
+        },
+      };
 
-      final parsedTd = ThingDescription(thingDescriptionJson);
+      final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
 
       final servient = Servient(clientFactories: [HttpClientFactory()]);
       final wot = await servient.start();

--- a/test/core/content_serdes_test.dart
+++ b/test/core/content_serdes_test.dart
@@ -23,7 +23,7 @@ void main() {
 
       final testContent1 = _getTestContent("42");
       final successfulSchema = DataSchema.fromJson(
-        <String, dynamic>{"type": "number"},
+        const <String, dynamic>{"type": "number"},
         PrefixMapping(),
       );
 
@@ -34,7 +34,7 @@ void main() {
 
       final testContent2 = _getTestContent("42");
       final failingSchema = DataSchema.fromJson(
-        <String, dynamic>{"type": "string"},
+        const <String, dynamic>{"type": "string"},
         PrefixMapping(),
       );
 
@@ -147,7 +147,7 @@ void main() {
         () => contentSerdes.valueToContent(
           null,
           // FIXME(JKRhb): Should not be necessary to use fromJson here
-          DataSchema.fromJson({"type": "object"}, PrefixMapping()),
+          DataSchema.fromJson(const {"type": "object"}, PrefixMapping()),
         ),
         throwsA(isA<ContentSerdesException>()),
       );

--- a/test/core/dart_wot_test.dart
+++ b/test/core/dart_wot_test.dart
@@ -16,56 +16,55 @@ void main() {
       // Additional setup goes here.
     });
 
-    test("Parse incomplete Thing Description", () async {
-      final servient = Servient();
-      final wot = await servient.start();
-      final Map<String, dynamic> exposedThingInit = <String, dynamic>{
-        "@context": "https://www.w3.org/2022/wot/td/v1.1",
-        "title": "Test Thing",
-      };
-      final dynamic exposedThing = await wot.produce(exposedThingInit);
-      // ignore: avoid_dynamic_calls
-      expect(exposedThing.id.startsWith("urn:uuid:"), true);
-    });
+    test(
+      "Parse incomplete Thing Description",
+      () async {
+        final servient = Servient();
+        final wot = await servient.start();
+        final Map<String, dynamic> exposedThingInit = <String, dynamic>{
+          "@context": "https://www.w3.org/2022/wot/td/v1.1",
+          "title": "Test Thing",
+        };
+        final exposedThing = await wot.produce(exposedThingInit);
+        expect(exposedThing.thingDescription.id?.startsWith("urn:uuid:"), true);
+      },
+    );
 
     test("Parse Thing Description", () {
-      const thingDescriptionJson = '''
-      {
-        "@context": ["http://www.w3.org/ns/td", {"@language": "de"}],
+      const thingDescriptionJson = {
+        "@context": [
+          "https://www.w3.org/2022/wot/td/v1.1",
+          {"@language": "de"},
+        ],
         "title": "Test Thing",
         "properties": {
           "status": {
             "forms": [
-              {
-                "href": "coap://example.org"
-              }
-            ]
-          }
+              {"href": "coap://example.org"},
+            ],
+          },
         },
         "links": [
           {
             "href": "https://example.org",
-            "rel": "test",
+            "rel": "icon",
             "anchor": "https://example.org",
             "@type": "test",
-            "sizes": "42",
+            "sizes": "42x42",
             "test": "test",
-            "hreflang": "de"
+            "hreflang": "de",
           },
           {
             "href": "https://example.org",
-            "hreflang": ["de", "en"]
+            "hreflang": ["de", "en"],
           }
         ],
         "securityDefinitions": {
-          "nosec_sc": {
-            "scheme": "nosec"
-          }
+          "nosec_sc": {"scheme": "nosec"},
         },
-        "security": ["nosec_sc"]
-      }
-      ''';
-      final parsedTd = ThingDescription(thingDescriptionJson);
+        "security": ["nosec_sc"],
+      };
+      final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
 
       expect(parsedTd.title, "Test Thing");
 
@@ -73,7 +72,7 @@ void main() {
       final secondContextEntry = parsedTd.context[1];
 
       expect(firstContextEntry.key, null);
-      expect(firstContextEntry.value, "http://www.w3.org/ns/td");
+      expect(firstContextEntry.value, "https://www.w3.org/2022/wot/td/v1.1");
       expect(secondContextEntry.key, "@language");
       expect(secondContextEntry.value, "de");
 
@@ -81,28 +80,28 @@ void main() {
       final securityDefinition = parsedTd.securityDefinitions["nosec_sc"]!;
       expect(securityDefinition.scheme, "nosec");
 
-      final parsedLink = parsedTd.links[0];
-      expect(parsedLink.href, Uri.parse("https://example.org"));
-      expect(parsedLink.rel, "test");
-      expect(parsedLink.anchor, Uri.parse("https://example.org"));
-      expect(parsedLink.type, "test");
-      expect(parsedLink.sizes, "42");
-      expect(parsedLink.hreflang, ["de"]);
-      expect(parsedLink.additionalFields["test"], "test");
+      final parsedLink = parsedTd.links?[0];
+      expect(parsedLink?.href, Uri.parse("https://example.org"));
+      expect(parsedLink?.rel, "icon");
+      expect(parsedLink?.anchor, Uri.parse("https://example.org"));
+      expect(parsedLink?.type, "test");
+      expect(parsedLink?.sizes, "42x42");
+      expect(parsedLink?.hreflang, ["de"]);
+      expect(parsedLink?.additionalFields?["test"], "test");
 
-      final secondParsedLink = parsedTd.links[1];
-      expect(secondParsedLink.hreflang, ["de", "en"]);
+      final secondParsedLink = parsedTd.links?[1];
+      expect(secondParsedLink?.hreflang, ["de", "en"]);
     });
 
     test("Link Tests", () {
       final link = Link(
-        "https://example.org",
+        Uri.parse("https://example.org"),
         type: "test",
         rel: "test",
-        anchor: "https://example.org",
+        anchor: Uri.parse("https://example.org"),
         sizes: "42",
-        additionalFields: <String, dynamic>{"test": "test"},
-        hreflang: ["de"],
+        additionalFields: const <String, dynamic>{"test": "test"},
+        hreflang: const ["de"],
       );
       expect(link.href, Uri.parse("https://example.org"));
       expect(link.rel, "test");
@@ -110,12 +109,12 @@ void main() {
       expect(link.hreflang, ["de"]);
       expect(link.type, "test");
       expect(link.sizes, "42");
-      expect(link.additionalFields["test"], "test");
+      expect(link.additionalFields?["test"], "test");
 
-      final link2 = Link("https://example.org");
+      final link2 = Link(Uri.parse("https://example.org"));
       expect(link2.href, Uri.parse("https://example.org"));
       expect(link2.anchor, null);
-      expect(link2.additionalFields, <String, dynamic>{});
+      expect(link2.additionalFields, isNull);
     });
   });
 }

--- a/test/core/operation_type_test.dart
+++ b/test/core/operation_type_test.dart
@@ -1,0 +1,67 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/src/definitions/data_schema.dart";
+import "package:dart_wot/src/definitions/interaction_affordances/interaction_affordance.dart";
+import "package:dart_wot/src/definitions/operation_type.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("OperationType should indicate the correct default op values for", () {
+    test("properties", () {
+      const regularProperty = Property(forms: []);
+
+      final regularPropertyOpValues =
+          OperationType.defaultOpValues(regularProperty);
+      expect(regularPropertyOpValues, [
+        OperationType.writeproperty,
+        OperationType.readproperty,
+      ]);
+
+      const writeOnlyProperty = Property(
+        forms: [],
+        dataSchema: DataSchema(writeOnly: true),
+      );
+
+      final writeOnlyPropertyOpValues =
+          OperationType.defaultOpValues(writeOnlyProperty);
+      expect(writeOnlyPropertyOpValues, [
+        OperationType.writeproperty,
+      ]);
+
+      const readOnlyProperty = Property(
+        forms: [],
+        dataSchema: DataSchema(readOnly: true),
+      );
+
+      final readOnlyPropertyOpValues =
+          OperationType.defaultOpValues(readOnlyProperty);
+      expect(readOnlyPropertyOpValues, [
+        OperationType.readproperty,
+      ]);
+    });
+
+    test("actions", () {
+      const regularAction = Action(forms: []);
+
+      final regularActionOpValues =
+          OperationType.defaultOpValues(regularAction);
+      expect(regularActionOpValues, [
+        OperationType.invokeaction,
+      ]);
+    });
+
+    test("events", () {
+      const regularEvent = Event(forms: []);
+
+      final regularEventOpValues = OperationType.defaultOpValues(regularEvent);
+      expect(regularEventOpValues, [
+        OperationType.subscribeevent,
+        OperationType.unsubscribeevent,
+      ]);
+    });
+  });
+}

--- a/test/core/thing_description_test.dart
+++ b/test/core/thing_description_test.dart
@@ -1,0 +1,46 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/dart_wot.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ThingDescription should", () {
+    test("be able to be instantiated from a ThingModel", () {
+      final json = {
+        "title": "Test TM",
+      };
+      final thingModel = ThingModel.fromJson(json);
+
+      // TODO(JKRhb): Implement fromThingModel constructor
+      expect(
+        () => ThingDescription.fromThingModel(thingModel),
+        throwsUnimplementedError,
+      );
+    });
+  });
+
+  test("be able to be converted to a Map<String, dynamic>", () {
+    const thingDescriptionJson = {
+      "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1",
+        {"@language": "de"},
+      ],
+      "title": "Test Thing",
+      "securityDefinitions": {
+        "nosec_sc": {"scheme": "nosec"},
+      },
+      "security": ["nosec_sc"],
+    };
+    final thingDescription = thingDescriptionJson.toThingDescription();
+
+    // TODO(JKRhb): Implement toJson method
+    expect(
+      thingDescription.toJson,
+      throwsUnimplementedError,
+    );
+  });
+}

--- a/test/core/thing_model_test.dart
+++ b/test/core/thing_model_test.dart
@@ -1,0 +1,22 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/dart_wot.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("ThingModel should", () {
+    test("be able to be instantiated", () {
+      final json = {
+        "title": "Test TM",
+      };
+      final thingModel = ThingModel.fromJson(json);
+
+      expect(thingModel.title, "Test TM");
+      expect(thingModel.id, isNull);
+    });
+  });
+}


### PR DESCRIPTION
This PR reworks the serialization and general data models used for Thing Descriptions, and improves the code coverage. Due to the rework, a couple of bugs are fixed, especially regarding JSON Schema validation and URI variables. However, especially regarding the latter, some more work is still needed.

One important piece for simplifying the data models is introducing a new `AugmentedForm` class where most of the logic from interaction-affordance-specific forms is being moved while the data model classes are labeled as `@immutable`. This should make the library a bit more reliable and should also slightly improve performance due to the use of `const` constructors.