### PR TITLE
style: prefer double quotes over single quotes for Strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Afterward, the actual interactions with the counter are performed by calling the
 `invokeAction()` and `readProperty()` methods on the `ConsumedThing`.
 
 ```dart
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
 Future<void> main(List<String> args) async {
   final servient = Servient(
@@ -59,22 +59,22 @@ Future<void> main(List<String> args) async {
   );
   final wot = await servient.start();
 
-  final url = Uri.parse('coap://plugfest.thingweb.io/counter');
-  print('Requesting TD from $url ...');
+  final url = Uri.parse("coap://plugfest.thingweb.io/counter");
+  print("Requesting TD from $url ...");
   final thingDescription = await wot.requestThingDescription(url);
 
   final consumedThing = await wot.consume(thingDescription);
   print(
-    'Successfully retrieved and consumed TD with title '
+    "Successfully retrieved and consumed TD with title "
     '"${thingDescription.title}"!',
   );
 
-  print('Incrementing counter ...');
-  await consumedThing.invokeAction('increment');
+  print("Incrementing counter ...");
+  await consumedThing.invokeAction("increment");
 
-  final status = await consumedThing.readProperty('count');
+  final status = await consumedThing.readProperty("count");
   final value = await status.value();
-  print('New counter value: $value');
+  print("New counter value: $value");
 }
 ```
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -7,7 +7,7 @@ linter:
   rules:
     always_use_package_imports: false
     prefer_relative_imports: true
-    prefer_single_quotes: true
+    prefer_double_quotes: true
     sort_constructors_first: true
     unawaited_futures: true
     public_member_api_docs: true

--- a/example/coap_discovery.dart
+++ b/example/coap_discovery.dart
@@ -6,9 +6,9 @@
 
 // ignore_for_file: avoid_print
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
-const propertyName = 'string';
+const propertyName = "string";
 
 extension PrintExtension on InteractionOutput {
   Future<void> printValue() async {
@@ -23,13 +23,13 @@ Future<void> handleThingDescription(
   final consumedThing = await wot.consume(thingDescription);
   await consumedThing.writeProperty(
     propertyName,
-    'Hello World'.asInteractionInput(),
+    "Hello World".asInteractionInput(),
   );
   var output = await consumedThing.readProperty(propertyName);
   await output.printValue();
   await consumedThing.writeProperty(
     propertyName,
-    'Bye Value'.asInteractionInput(),
+    "Bye Value".asInteractionInput(),
   );
   output = await consumedThing.readProperty(propertyName);
   await output.printValue();
@@ -39,7 +39,7 @@ Future<void> main(List<String> args) async {
   final servient = Servient(clientFactories: [CoapClientFactory()]);
 
   final wot = await servient.start();
-  final uri = Uri.parse('coap://plugfest.thingweb.io:5683/testthing');
+  final uri = Uri.parse("coap://plugfest.thingweb.io:5683/testthing");
 
   // Example using for-await-loop
   try {
@@ -59,7 +59,7 @@ Future<void> main(List<String> args) async {
     (thingDescription) async {
       await handleThingDescription(wot, thingDescription);
     },
-    onError: (error) => print('Encountered an error: $error'),
+    onError: (error) => print("Encountered an error: $error"),
     onDone: () => print('Discovery with "listen" has finished.'),
   );
 }

--- a/example/coap_dns_sd_discovery.dart
+++ b/example/coap_dns_sd_discovery.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: avoid_print
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
 void handleThingDescription(ThingDescription thingDescription) =>
     print('Discovered TD with title "${thingDescription.title}".');
@@ -19,7 +19,7 @@ Future<void> main(List<String> args) async {
   );
 
   final wot = await servient.start();
-  final uri = Uri.parse('_wot._udp.local');
+  final uri = Uri.parse("_wot._udp.local");
 
   // Example using for-await-loop
   try {
@@ -38,7 +38,7 @@ Future<void> main(List<String> args) async {
   // to the handleThingDescription function.
   wot.discover(uri, method: DiscoveryMethod.dnsServiceDiscovery).listen(
         handleThingDescription,
-        onError: (error) => print('Encountered an error: $error'),
+        onError: (error) => print("Encountered an error: $error"),
         onDone: () => print('Discovery with "listen" has finished.'),
       );
 }

--- a/example/coaps_readproperty.dart
+++ b/example/coaps_readproperty.dart
@@ -6,15 +6,15 @@
 
 // ignore_for_file: avoid_print
 
-import 'dart:typed_data';
+import "dart:typed_data";
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
 /// Matches [PskCredentials] by hostname and URI scheme.
 final Map<Uri, PskCredentials> _pskCredentialsStore = {
-  Uri(host: 'californium.eclipseprojects.io', scheme: 'coaps'): PskCredentials(
-    identity: Uint8List.fromList('Client_identity'.codeUnits),
-    preSharedKey: Uint8List.fromList('secretPSK'.codeUnits),
+  Uri(host: "californium.eclipseprojects.io", scheme: "coaps"): PskCredentials(
+    identity: Uint8List.fromList("Client_identity".codeUnits),
+    preSharedKey: Uint8List.fromList("secretPSK".codeUnits),
   ),
 };
 
@@ -31,7 +31,7 @@ PskCredentials? _pskCredentialsCallback(
 Future<void> main(List<String> args) async {
   final CoapClientFactory coapClientFactory = CoapClientFactory(
     coapConfig: const CoapConfig(
-      dtlsCiphers: 'PSK-AES128-CCM8',
+      dtlsCiphers: "PSK-AES128-CCM8",
     ),
     pskCredentialsCallback: _pskCredentialsCallback,
   );
@@ -70,7 +70,7 @@ Future<void> main(List<String> args) async {
 
   final thingDescription = ThingDescription(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
-  final status = await consumedThing.readProperty('status');
+  final status = await consumedThing.readProperty("status");
   final value = await status.value();
   print(value);
 }

--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: avoid_print
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
 const thingDescriptionJson = '''
 {
@@ -98,7 +98,7 @@ const thingDescriptionJson = '''
 ''';
 
 final Map<String, BasicCredentials> basicCredentials = {
-  'urn:test': BasicCredentials('username', 'password'),
+  "urn:test": BasicCredentials("username", "password"),
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(
@@ -129,17 +129,17 @@ Future<void> main() async {
 
   final thingDescription = ThingDescription(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
-  final status = await consumedThing.readProperty('status');
+  final status = await consumedThing.readProperty("status");
   final value1 = await status.value();
   print(value1);
-  await consumedThing.invokeAction('toggle');
-  final status2 = await consumedThing.readProperty('differentStatus');
+  await consumedThing.invokeAction("toggle");
+  final status2 = await consumedThing.readProperty("differentStatus");
   final value2 = await status2.value();
   print(value2);
 
   final status3 = await consumedThing.readProperty(
-    'anotherStatus',
-    uriVariables: {'test': 'hi'},
+    "anotherStatus",
+    uriVariables: {"test": "hi"},
   );
   final value3 = await status3.value();
   print(value3);
@@ -147,24 +147,24 @@ Future<void> main() async {
   Subscription? subscription;
 
   int observationCounter = 0;
-  subscription = await consumedThing.observeProperty('status', (data) async {
+  subscription = await consumedThing.observeProperty("status", (data) async {
     if (observationCounter++ == 3) {
-      print('Done! Cancelling subscription.');
+      print("Done! Cancelling subscription.");
       await subscription?.stop();
     }
 
     if (subscription?.active ?? false) {
       final value = await data.value();
-      print('Received observation data: $value');
+      print("Received observation data: $value");
     }
   });
 
-  await consumedThing.readProperty('test');
+  await consumedThing.readProperty("test");
 
   final thingUri = Uri.parse(
-    'https://raw.githubusercontent.com/w3c/wot-testing'
-    '/b07fa6124bca7796e6ca752a3640fac264d3bcbc/events/2021.03.Online/TDs'
-    '/Oracle/oracle-Festo_Shared.td.jsonld',
+    "https://raw.githubusercontent.com/w3c/wot-testing"
+    "/b07fa6124bca7796e6ca752a3640fac264d3bcbc/events/2021.03.Online/TDs"
+    "/Oracle/oracle-Festo_Shared.td.jsonld",
   );
 
   final thingDiscovery = wot.discover(thingUri);
@@ -172,8 +172,8 @@ Future<void> main() async {
   await for (final thingDescription in thingDiscovery) {
     final consumedDiscoveredThing = await wot.consume(thingDescription);
     print(
-      'The title of the fetched TD is '
-      '${consumedDiscoveredThing.thingDescription.title}.',
+      "The title of the fetched TD is "
+      "${consumedDiscoveredThing.thingDescription.title}.",
     );
   }
 }

--- a/example/core_link_format_discovery.dart
+++ b/example/core_link_format_discovery.dart
@@ -6,10 +6,10 @@
 
 // ignore_for_file: avoid_print
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
-const propertyName = 'status';
-const actionName = 'toggle';
+const propertyName = "status";
+const actionName = "toggle";
 
 Future<void> main(List<String> args) async {
   final servient = Servient(clientFactories: [CoapClientFactory()]);
@@ -19,7 +19,7 @@ Future<void> main(List<String> args) async {
   // TODO(JKRhb): Replace with an endpoint providing CoRE Format Links pointing
   //              to TDs. At the moment, this URI is just for illustrative
   //              purpose and will not return actual Thing Description links.
-  final discoveryUri = Uri.parse('coap://coap.me/.well-known/core');
+  final discoveryUri = Uri.parse("coap://coap.me/.well-known/core");
 
   await for (final thingDescription
       in wot.discover(discoveryUri, method: DiscoveryMethod.coreLinkFormat)) {

--- a/example/example.dart
+++ b/example/example.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: avoid_print
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
 Future<void> main(List<String> args) async {
   final servient = Servient(
@@ -16,20 +16,20 @@ Future<void> main(List<String> args) async {
   );
   final wot = await servient.start();
 
-  final url = Uri.parse('coap://plugfest.thingweb.io/counter');
-  print('Requesting TD from $url ...');
+  final url = Uri.parse("coap://plugfest.thingweb.io/counter");
+  print("Requesting TD from $url ...");
   final thingDescription = await wot.requestThingDescription(url);
 
   final consumedThing = await wot.consume(thingDescription);
   print(
-    'Successfully retrieved and consumed TD with title '
+    "Successfully retrieved and consumed TD with title "
     '"${thingDescription.title}"!',
   );
 
-  print('Incrementing counter ...');
-  await consumedThing.invokeAction('increment');
+  print("Incrementing counter ...");
+  await consumedThing.invokeAction("increment");
 
-  final status = await consumedThing.readProperty('count');
+  final status = await consumedThing.readProperty("count");
   final value = await status.value();
-  print('New counter value: $value');
+  print("New counter value: $value");
 }

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -6,10 +6,10 @@
 
 // ignore_for_file: avoid_print
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
-const username = 'username';
-const password = 'password';
+const username = "username";
+const password = "password";
 const thingDescriptionJson = '''
       {
         "@context": ["http://www.w3.org/ns/td"],
@@ -45,10 +45,10 @@ const thingDescriptionJson = '''
       }
       ''';
 
-final basicCredentials = BasicCredentials('username', 'password');
+final basicCredentials = BasicCredentials("username", "password");
 
 final Map<String, BasicCredentials> basicCredentialsMap = {
-  'urn:test': basicCredentials,
+  "urn:test": basicCredentials,
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(
@@ -80,11 +80,11 @@ Future<void> main(List<String> args) async {
 
   final thingDescription = ThingDescription(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
-  final status = await consumedThing.readProperty('status');
+  final status = await consumedThing.readProperty("status");
 
   print(await status.value());
 
-  final status2 = await consumedThing.readProperty('status2');
+  final status2 = await consumedThing.readProperty("status2");
 
   print(await status2.value());
 }

--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -6,7 +6,7 @@
 
 // ignore_for_file: avoid_print
 
-import 'package:dart_wot/dart_wot.dart';
+import "package:dart_wot/dart_wot.dart";
 
 const thingDescriptionJson = '''
   {
@@ -51,7 +51,7 @@ const thingDescriptionJson = '''
   ''';
 
 final Map<String, BasicCredentials> basicCredentials = {
-  'urn:test': BasicCredentials('rw', 'readwrite'),
+  "urn:test": BasicCredentials("rw", "readwrite"),
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(
@@ -75,27 +75,27 @@ Future<void> main(List<String> args) async {
 
   final thingDescription = ThingDescription(thingDescriptionJson);
   final consumedThing = await wot.consume(thingDescription);
-  await consumedThing.readAndPrintProperty('status');
+  await consumedThing.readAndPrintProperty("status");
 
   final subscription = await consumedThing.observeProperty(
-    'status',
+    "status",
     (data) async {
       final value = await data.value();
       print(value);
     },
   );
 
-  final actionInput = 'Hello World'.asInteractionInput();
+  final actionInput = "Hello World".asInteractionInput();
 
-  await consumedThing.invokeAction('toggle', input: actionInput);
-  await consumedThing.invokeAction('toggle', input: actionInput);
-  await consumedThing.invokeAction('toggle', input: actionInput);
-  await consumedThing.invokeAction('toggle', input: actionInput);
+  await consumedThing.invokeAction("toggle", input: actionInput);
+  await consumedThing.invokeAction("toggle", input: actionInput);
+  await consumedThing.invokeAction("toggle", input: actionInput);
+  await consumedThing.invokeAction("toggle", input: actionInput);
   await subscription.stop();
 
-  await consumedThing.invokeAction('toggle', input: actionInput);
-  await consumedThing.readAndPrintProperty('status');
-  print('Done!');
+  await consumedThing.invokeAction("toggle", input: actionInput);
+  await consumedThing.readAndPrintProperty("status");
+  print("Done!");
 }
 
 extension ReadAndPrintExtension on ConsumedThing {

--- a/lib/binding_coap.dart
+++ b/lib/binding_coap.dart
@@ -10,6 +10,6 @@
 /// [spec link]: https://www.w3.org/TR/wot-binding-templates/
 library binding_coap;
 
-export 'src/binding_coap/coap_client_factory.dart';
-export 'src/binding_coap/coap_config.dart';
-export 'src/binding_coap/coap_server.dart';
+export "src/binding_coap/coap_client_factory.dart";
+export "src/binding_coap/coap_config.dart";
+export "src/binding_coap/coap_server.dart";

--- a/lib/binding_http.dart
+++ b/lib/binding_http.dart
@@ -10,6 +10,6 @@
 /// [spec link]: https://www.w3.org/TR/wot-binding-templates/
 library binding_http;
 
-export 'src/binding_http/http_client_factory.dart';
-export 'src/binding_http/http_config.dart';
-export 'src/binding_http/http_server.dart';
+export "src/binding_http/http_client_factory.dart";
+export "src/binding_http/http_config.dart";
+export "src/binding_http/http_server.dart";

--- a/lib/binding_mqtt.dart
+++ b/lib/binding_mqtt.dart
@@ -10,5 +10,5 @@
 /// [spec link]: https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt
 library binding_mqtt;
 
-export 'src/binding_mqtt/mqtt_client_factory.dart';
-export 'src/binding_mqtt/mqtt_config.dart';
+export "src/binding_mqtt/mqtt_client_factory.dart";
+export "src/binding_mqtt/mqtt_config.dart";

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -9,20 +9,20 @@
 /// runtime used for consuming, exposing, and discovering Things.
 library core;
 
-export 'package:dcaf/dcaf.dart';
+export "package:dcaf/dcaf.dart";
 
-export 'src/core/codecs/content_codec.dart';
-export 'src/core/content_serdes.dart';
-export 'src/core/credentials/ace_credentials.dart';
-export 'src/core/credentials/apikey_credentials.dart';
-export 'src/core/credentials/basic_credentials.dart';
-export 'src/core/credentials/bearer_credentials.dart';
-export 'src/core/credentials/callbacks.dart';
-export 'src/core/credentials/credentials.dart';
-export 'src/core/credentials/digest_credentials.dart';
-export 'src/core/credentials/oauth2_credentials.dart';
-export 'src/core/credentials/psk_credentials.dart';
-export 'src/core/protocol_interfaces/protocol_client.dart';
-export 'src/core/protocol_interfaces/protocol_client_factory.dart';
-export 'src/core/protocol_interfaces/protocol_server.dart';
-export 'src/core/servient.dart';
+export "src/core/codecs/content_codec.dart";
+export "src/core/content_serdes.dart";
+export "src/core/credentials/ace_credentials.dart";
+export "src/core/credentials/apikey_credentials.dart";
+export "src/core/credentials/basic_credentials.dart";
+export "src/core/credentials/bearer_credentials.dart";
+export "src/core/credentials/callbacks.dart";
+export "src/core/credentials/credentials.dart";
+export "src/core/credentials/digest_credentials.dart";
+export "src/core/credentials/oauth2_credentials.dart";
+export "src/core/credentials/psk_credentials.dart";
+export "src/core/protocol_interfaces/protocol_client.dart";
+export "src/core/protocol_interfaces/protocol_client_factory.dart";
+export "src/core/protocol_interfaces/protocol_server.dart";
+export "src/core/servient.dart";

--- a/lib/dart_wot.dart
+++ b/lib/dart_wot.dart
@@ -7,9 +7,9 @@
 /// A W3C Web of Things implementation written in Dart.
 library dart_wot;
 
-export 'binding_coap.dart';
-export 'binding_http.dart';
-export 'binding_mqtt.dart';
-export 'core.dart';
-export 'definitions.dart';
-export 'scripting_api.dart';
+export "binding_coap.dart";
+export "binding_http.dart";
+export "binding_mqtt.dart";
+export "core.dart";
+export "definitions.dart";
+export "scripting_api.dart";

--- a/lib/definitions.dart
+++ b/lib/definitions.dart
@@ -10,8 +10,8 @@
 /// [spec link]: https://www.w3.org/TR/wot-thing-description11/
 library definitions;
 
-export 'src/definitions/form.dart';
-export 'src/definitions/thing_description.dart';
-export 'src/definitions/thing_model.dart';
-export 'src/definitions/validation/thing_description_schema.dart'
+export "src/definitions/form.dart";
+export "src/definitions/thing_description.dart";
+export "src/definitions/thing_model.dart";
+export "src/definitions/validation/thing_description_schema.dart"
     show thingDescriptionSchema;

--- a/lib/scripting_api.dart
+++ b/lib/scripting_api.dart
@@ -10,14 +10,14 @@
 /// [spec link]: https://www.w3.org/TR/wot-scripting-api/
 library scripting_api;
 
-export 'src/scripting_api/consumed_thing.dart';
-export 'src/scripting_api/data_schema_value.dart';
-export 'src/scripting_api/discovery/discovery_method.dart';
-export 'src/scripting_api/discovery/thing_discovery.dart';
-export 'src/scripting_api/discovery/thing_filter.dart';
-export 'src/scripting_api/exposed_thing.dart';
-export 'src/scripting_api/interaction_input.dart';
-export 'src/scripting_api/interaction_output.dart';
-export 'src/scripting_api/subscription.dart';
-export 'src/scripting_api/types.dart';
-export 'src/scripting_api/wot.dart';
+export "src/scripting_api/consumed_thing.dart";
+export "src/scripting_api/data_schema_value.dart";
+export "src/scripting_api/discovery/discovery_method.dart";
+export "src/scripting_api/discovery/thing_discovery.dart";
+export "src/scripting_api/discovery/thing_filter.dart";
+export "src/scripting_api/exposed_thing.dart";
+export "src/scripting_api/interaction_input.dart";
+export "src/scripting_api/interaction_output.dart";
+export "src/scripting_api/subscription.dart";
+export "src/scripting_api/types.dart";
+export "src/scripting_api/wot.dart";

--- a/lib/src/binding_coap/coap_binding_exception.dart
+++ b/lib/src/binding_coap/coap_binding_exception.dart
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:coap/coap.dart';
+import "package:coap/coap.dart";
 
 /// This [Exception] is thrown when an error within the CoAP Binding occurs.
 class CoapBindingException implements Exception {
@@ -18,7 +18,7 @@ class CoapBindingException implements Exception {
 
   @override
   String toString() {
-    return 'CoapBindingException: $_message';
+    return "CoapBindingException: $_message";
   }
 }
 
@@ -27,7 +27,7 @@ abstract class CoapBindingResponseException extends CoapBindingException {
   /// Constructor.
   CoapBindingResponseException(CoapResponse response)
       : super(
-          '${response.statusCodeString}. Payload: ${response.payloadString}',
+          "${response.statusCodeString}. Payload: ${response.payloadString}",
         );
 }
 
@@ -37,7 +37,7 @@ class CoapClientErrorException extends CoapBindingResponseException {
   CoapClientErrorException(super.response);
 
   @override
-  String toString() => 'CoapClientErrorException: $_message';
+  String toString() => "CoapClientErrorException: $_message";
 }
 
 /// [Exception] that is thrown if a server error occurs.
@@ -46,5 +46,5 @@ class CoapServerErrorException extends CoapBindingResponseException {
   CoapServerErrorException(super.response);
 
   @override
-  String toString() => 'CoapServerErrorException: $_message';
+  String toString() => "CoapServerErrorException: $_message";
 }

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -4,26 +4,26 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:async';
-import 'dart:typed_data';
+import "dart:async";
+import "dart:typed_data";
 
-import 'package:coap/coap.dart' as coap;
-import 'package:coap/config/coap_config_default.dart';
-import 'package:dcaf/dcaf.dart';
+import "package:coap/coap.dart" as coap;
+import "package:coap/config/coap_config_default.dart";
+import "package:dcaf/dcaf.dart";
 
-import '../core/content.dart';
-import '../core/credentials/ace_credentials.dart';
-import '../core/credentials/callbacks.dart';
-import '../core/credentials/psk_credentials.dart';
-import '../core/protocol_interfaces/protocol_client.dart';
-import '../definitions/form.dart';
-import '../definitions/operation_type.dart';
-import '../scripting_api/subscription.dart';
-import 'coap_binding_exception.dart';
-import 'coap_config.dart';
-import 'coap_definitions.dart';
-import 'coap_extensions.dart';
-import 'coap_subscription.dart';
+import "../core/content.dart";
+import "../core/credentials/ace_credentials.dart";
+import "../core/credentials/callbacks.dart";
+import "../core/credentials/psk_credentials.dart";
+import "../core/protocol_interfaces/protocol_client.dart";
+import "../definitions/form.dart";
+import "../definitions/operation_type.dart";
+import "../scripting_api/subscription.dart";
+import "coap_binding_exception.dart";
+import "coap_config.dart";
+import "coap_definitions.dart";
+import "coap_extensions.dart";
+import "coap_subscription.dart";
 
 class _InternalCoapConfig extends CoapConfigDefault {
   _InternalCoapConfig(CoapConfig coapConfig)
@@ -67,7 +67,7 @@ coap.PskCredentialsCallback? _createPskCallback(
 
     if (pskCredentials == null) {
       throw CoapBindingException(
-        'Missing PSK credentials for CoAPS request!',
+        "Missing PSK credentials for CoAPS request!",
       );
     }
 
@@ -234,7 +234,7 @@ final class CoapClient implements ProtocolClient {
   ) async {
     final requestMethod = (form.method ?? CoapRequestMethod.get).code;
 
-    final creationHintUri = form.resolvedHref.replace(scheme: 'coap');
+    final creationHintUri = form.resolvedHref.replace(scheme: "coap");
 
     final request = await _createRequest(
       requestMethod,
@@ -279,7 +279,7 @@ final class CoapClient implements ProtocolClient {
       creationHint = await _obtainCreationHintFromResourceServer(form);
     }
 
-    final textScopes = aceSecurityScheme.scopes?.join(' ');
+    final textScopes = aceSecurityScheme.scopes?.join(" ");
     // TODO: Do the scopes defined for a form need to be considered here as
     //       well?
     TextScope? scope;
@@ -312,13 +312,13 @@ final class CoapClient implements ProtocolClient {
     );
 
     if (aceCredentials == null) {
-      throw CoapBindingException('Missing ACE-OAuth Credentials');
+      throw CoapBindingException("Missing ACE-OAuth Credentials");
     }
 
     final pskCredentials = aceCredentials.accessToken.pskCredentials;
 
     final client = coap.CoapClient(
-      request.uri.replace(scheme: 'coaps'),
+      request.uri.replace(scheme: "coaps"),
       pskCredentialsCallback: (identityHint) => pskCredentials,
     );
 

--- a/lib/src/binding_coap/coap_client_factory.dart
+++ b/lib/src/binding_coap/coap_client_factory.dart
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../core/credentials/callbacks.dart';
-import '../core/protocol_interfaces/protocol_client.dart';
-import '../core/protocol_interfaces/protocol_client_factory.dart';
-import 'coap_client.dart';
-import 'coap_config.dart';
+import "../core/credentials/callbacks.dart";
+import "../core/protocol_interfaces/protocol_client.dart";
+import "../core/protocol_interfaces/protocol_client_factory.dart";
+import "coap_client.dart";
+import "coap_config.dart";
 
 /// A [ProtocolClientFactory] that produces CoAP clients.
 final class CoapClientFactory implements ProtocolClientFactory {
@@ -28,7 +28,7 @@ final class CoapClientFactory implements ProtocolClientFactory {
   final AceSecurityCallback? _aceSecurityCallback;
 
   @override
-  Set<String> get schemes => {'coap', 'coaps'};
+  Set<String> get schemes => {"coap", "coaps"};
 
   @override
   bool destroy() {

--- a/lib/src/binding_coap/coap_config.dart
+++ b/lib/src/binding_coap/coap_config.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:typed_data';
+import "dart:typed_data";
 
-import 'package:meta/meta.dart';
+import "package:meta/meta.dart";
 
 /// Allows for configuring the behavior of CoAP clients and servers.
 @immutable

--- a/lib/src/binding_coap/coap_definitions.dart
+++ b/lib/src/binding_coap/coap_definitions.dart
@@ -4,14 +4,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:collection';
+import "dart:collection";
 
-import 'package:coap/coap.dart';
-import 'package:curie/curie.dart';
+import "package:coap/coap.dart";
+import "package:curie/curie.dart";
 
 /// [PrefixMapping] for expanding CoAP Vocabulary terms from compact IRIs.
 final coapPrefixMapping =
-    PrefixMapping(defaultPrefixValue: 'http://www.example.org/coap-binding#');
+    PrefixMapping(defaultPrefixValue: "http://www.example.org/coap-binding#");
 
 /// Defines the available CoAP request methods.
 enum CoapRequestMethod {

--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -1,20 +1,20 @@
-import 'dart:io';
-import 'dart:typed_data';
+import "dart:io";
+import "dart:typed_data";
 
-import 'package:cbor/cbor.dart';
-import 'package:coap/coap.dart';
-import 'package:dcaf/dcaf.dart';
+import "package:cbor/cbor.dart";
+import "package:coap/coap.dart";
+import "package:dcaf/dcaf.dart";
 
-import '../core/content.dart';
-import '../definitions/expected_response.dart';
-import '../definitions/form.dart';
-import '../definitions/operation_type.dart';
-import '../definitions/security/ace_security_scheme.dart';
-import '../definitions/security/auto_security_scheme.dart';
-import '../definitions/security/psk_security_scheme.dart';
-import '../definitions/validation/validation_exception.dart';
-import 'coap_binding_exception.dart';
-import 'coap_definitions.dart';
+import "../core/content.dart";
+import "../definitions/expected_response.dart";
+import "../definitions/form.dart";
+import "../definitions/operation_type.dart";
+import "../definitions/security/ace_security_scheme.dart";
+import "../definitions/security/auto_security_scheme.dart";
+import "../definitions/security/psk_security_scheme.dart";
+import "../definitions/validation/validation_exception.dart";
+import "coap_binding_exception.dart";
+import "coap_definitions.dart";
 
 /// Extension which makes it easier to handle [Uri]s containing
 /// [InternetAddress]es.
@@ -48,7 +48,7 @@ extension CoapFormExtension on Form {
 
   /// Get the [CoapSubprotocol] for this [Form], if one is set.
   CoapSubprotocol? get coapSubprotocol {
-    if (subprotocol == coapPrefixMapping.expandCurieString('observe')) {
+    if (subprotocol == coapPrefixMapping.expandCurieString("observe")) {
       return CoapSubprotocol.observe;
     }
 
@@ -57,7 +57,7 @@ extension CoapFormExtension on Form {
 
   /// The Content-Format for CoAP request and response payloads.
   CoapMediaType get contentFormat {
-    final formDefinition = _obtainVocabularyTerm<int>('contentFormat');
+    final formDefinition = _obtainVocabularyTerm<int>("contentFormat");
     final contentFormat = CoapMediaType.fromIntValue(formDefinition ?? -1);
 
     return contentFormat ??
@@ -68,13 +68,13 @@ extension CoapFormExtension on Form {
   /// The Content-Format for the Accept option CoAP request and response
   /// payloads.
   CoapMediaType? get accept {
-    final formDefinition = _obtainVocabularyTerm<int>('accept');
+    final formDefinition = _obtainVocabularyTerm<int>("accept");
     return CoapMediaType.fromIntValue(formDefinition ?? -1);
   }
 
   BlockSize? _determineBlockSize(String fieldName) {
     final blockwiseParameters =
-        _obtainVocabularyTerm<Map<String, dynamic>>('blockwise');
+        _obtainVocabularyTerm<Map<String, dynamic>>("blockwise");
 
     if (blockwiseParameters == null) {
       return null;
@@ -94,21 +94,21 @@ extension CoapFormExtension on Form {
       // ignore: avoid_catching_errors
     } on ArgumentError {
       throw ValidationException(
-        'Encountered invalid blocksize $value in CoAP form',
+        "Encountered invalid blocksize $value in CoAP form",
       );
     }
   }
 
   /// Indicates the Block2 size preferred by a server.
-  BlockSize? get block2Size => _determineBlockSize('block2Size');
+  BlockSize? get block2Size => _determineBlockSize("block2Size");
 
   /// Indicates the Block1 size preferred by a server.
-  BlockSize? get block1Size => _determineBlockSize('block1Size');
+  BlockSize? get block1Size => _determineBlockSize("block1Size");
 
   // TODO: Consider default method
   /// Indicates the [CoapRequestMethod] contained in this [Form].
   CoapRequestMethod? get method {
-    final methodDefinition = _obtainVocabularyTerm<String>('method');
+    final methodDefinition = _obtainVocabularyTerm<String>("method");
 
     if (methodDefinition == null) {
       return null;
@@ -137,7 +137,7 @@ extension CoapExpectedResponseExtension on ExpectedResponse {
 
   /// The Content-Format for CoAP request and response payloads.
   CoapMediaType get contentFormat {
-    final formDefinition = _obtainVocabularyTerm<int>('contentFormat');
+    final formDefinition = _obtainVocabularyTerm<int>("contentFormat");
     final contentFormat = CoapMediaType.fromIntValue(formDefinition ?? -1);
 
     return contentFormat ??
@@ -193,7 +193,7 @@ extension ResponseExtension on CoapResponse {
   Stream<List<int>> get _payloadStream => Stream.value(payload);
 
   String get _contentType =>
-      contentFormat?.contentType.toString() ?? 'application/json';
+      contentFormat?.contentType.toString() ?? "application/json";
 
   /// Extract the [Content] of this [CoapResponse].
   Content get content {
@@ -248,7 +248,7 @@ extension PskExtension on AccessTokenResponse {
     final aceProfile = this.aceProfile;
     if (aceProfile != null && aceProfile != AceProfile.coapDtls) {
       throw CoapBindingException(
-        'ACE-OAuth Profile $aceProfile is not supported.',
+        "ACE-OAuth Profile $aceProfile is not supported.",
       );
     }
   }
@@ -263,8 +263,8 @@ extension PskExtension on AccessTokenResponse {
     final cnf = this.cnf;
     if (cnf is! PlainCoseKey) {
       throw CoapBindingException(
-        'Proof of Possession Key for establishing a DTLS connection must be '
-        'symmetric',
+        "Proof of Possession Key for establishing a DTLS connection must be "
+        "symmetric",
       );
     }
     final key = cnf.key.parameters[-1];
@@ -273,8 +273,8 @@ extension PskExtension on AccessTokenResponse {
       preSharedKey = Uint8List.fromList(key.bytes);
     } else {
       throw CoapBindingException(
-        'Proof of Possession Key for establishing a DTLS connection must be '
-        'bytes',
+        "Proof of Possession Key for establishing a DTLS connection must be "
+        "bytes",
       );
     }
 

--- a/lib/src/binding_coap/coap_server.dart
+++ b/lib/src/binding_coap/coap_server.dart
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../core/credentials/callbacks.dart';
-import '../core/protocol_interfaces/protocol_server.dart';
-import '../scripting_api/exposed_thing.dart';
-import 'coap_config.dart';
+import "../core/credentials/callbacks.dart";
+import "../core/protocol_interfaces/protocol_server.dart";
+import "../scripting_api/exposed_thing.dart";
+import "coap_config.dart";
 
 /// A [ProtocolServer] for the Constrained Application Protocol (CoAP).
 final class CoapServer implements ProtocolServer {
@@ -18,7 +18,7 @@ final class CoapServer implements ProtocolServer {
 
   // TODO(JKRhb): Consider other protocol schemes.
   @override
-  final String scheme = 'coap';
+  final String scheme = "coap";
 
   @override
   final int port;

--- a/lib/src/binding_coap/coap_subscription.dart
+++ b/lib/src/binding_coap/coap_subscription.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:coap/coap.dart';
+import "package:coap/coap.dart";
 
-import '../scripting_api/subscription.dart';
+import "../scripting_api/subscription.dart";
 
 /// [Subscription] to a CoAP resource, based on the observe option ([RFC 7641]).
 ///

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -4,25 +4,25 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
-import 'dart:io';
+import "dart:convert";
+import "dart:io";
 
-import 'package:http/http.dart';
+import "package:http/http.dart";
 
-import '../core/content.dart';
-import '../core/credentials/basic_credentials.dart';
-import '../core/credentials/bearer_credentials.dart';
-import '../core/credentials/callbacks.dart';
-import '../core/protocol_interfaces/protocol_client.dart';
-import '../definitions/form.dart';
-import '../definitions/operation_type.dart';
-import '../definitions/security/basic_security_scheme.dart';
-import '../definitions/security/bearer_security_scheme.dart';
-import '../scripting_api/subscription.dart';
-import 'http_request_method.dart';
-import 'http_security_exception.dart';
+import "../core/content.dart";
+import "../core/credentials/basic_credentials.dart";
+import "../core/credentials/bearer_credentials.dart";
+import "../core/credentials/callbacks.dart";
+import "../core/protocol_interfaces/protocol_client.dart";
+import "../definitions/form.dart";
+import "../definitions/operation_type.dart";
+import "../definitions/security/basic_security_scheme.dart";
+import "../definitions/security/bearer_security_scheme.dart";
+import "../scripting_api/subscription.dart";
+import "http_request_method.dart";
+import "http_security_exception.dart";
 
-const _authorizationHeader = 'Authorization';
+const _authorizationHeader = "Authorization";
 
 /// A [ProtocolClient] for the Hypertext Transfer Protocol (HTTP).
 ///
@@ -121,16 +121,16 @@ final class HttpClient implements ProtocolClient {
     final username = credentials.username;
     final password = credentials.password;
 
-    final bytes = utf8.encode('$username:$password');
+    final bytes = utf8.encode("$username:$password");
     final base64Credentials = base64.encode(bytes);
-    request.headers[_authorizationHeader] = 'Basic $base64Credentials';
+    request.headers[_authorizationHeader] = "Basic $base64Credentials";
   }
 
   void _applyBearerCredentials(
     BearerCredentials credentials,
     Request request,
   ) {
-    request.headers[_authorizationHeader] = 'Bearer ${credentials.token}';
+    request.headers[_authorizationHeader] = "Bearer ${credentials.token}";
   }
 
   Request _copyRequest(Request request) {
@@ -147,7 +147,7 @@ final class HttpClient implements ProtocolClient {
     final basicCredentials = await _getBasicCredentials(request.url, form);
 
     if (basicCredentials == null) {
-      throw HttpSecurityException('No BasicCredentials have been provided.');
+      throw HttpSecurityException("No BasicCredentials have been provided.");
     }
 
     _applyBasicCredentials(basicCredentials, request);
@@ -163,7 +163,7 @@ final class HttpClient implements ProtocolClient {
     final bearerCredentials = await _getBearerCredentials(request.url, form);
 
     if (bearerCredentials == null) {
-      throw HttpSecurityException('No BearerCredentials have been provided.');
+      throw HttpSecurityException("No BearerCredentials have been provided.");
     }
 
     _applyBearerCredentials(bearerCredentials, request);
@@ -177,14 +177,14 @@ final class HttpClient implements ProtocolClient {
     Form? form,
   ]) async {
     if (response.statusCode == HttpStatus.unauthorized) {
-      final authenticate = response.headers['www-authenticate'];
+      final authenticate = response.headers["www-authenticate"];
 
       if (authenticate != null) {
-        final method = authenticate.split(' ')[0];
+        final method = authenticate.split(" ")[0];
         switch (method) {
-          case 'Basic':
+          case "Basic":
             return _createBasicAuthRequest(originalRequest, form);
-          case 'Bearer':
+          case "Bearer":
             return _createBearerAuthRequest(originalRequest, form);
         }
       }
@@ -230,13 +230,13 @@ final class HttpClient implements ProtocolClient {
   }
 
   static Map<String, String> _getHeadersFromForm(Form form) {
-    final Map<String, String> headers = {'Content-Type': form.contentType};
+    final Map<String, String> headers = {"Content-Type": form.contentType};
 
-    final dynamic formHeaders = form.additionalFields['htv:headers'];
+    final dynamic formHeaders = form.additionalFields["htv:headers"];
     if (formHeaders is List<Map<String, String>>) {
       for (final formHeader in formHeaders) {
-        final key = formHeader['htv:fieldName'];
-        final value = formHeader['htv:fieldValue'];
+        final key = formHeader["htv:fieldName"];
+        final value = formHeader["htv:fieldValue"];
 
         if (key != null && value != null) {
           headers[key] = value;
@@ -248,7 +248,7 @@ final class HttpClient implements ProtocolClient {
   }
 
   Content _contentFromResponse(Form form, StreamedResponse response) {
-    final type = response.headers['Content-Type'] ?? form.contentType;
+    final type = response.headers["Content-Type"] ?? form.contentType;
     final responseStream = response.stream.asBroadcastStream()
       ..listen(null, onDone: stop);
     return Content(type, responseStream);
@@ -298,11 +298,11 @@ final class HttpClient implements ProtocolClient {
     Request request, {
     required String acceptHeaderValue,
   }) async {
-    request.headers['Accept'] = acceptHeaderValue;
+    request.headers["Accept"] = acceptHeaderValue;
     final response = await _client.send(request);
     final finalResponse = await _handleResponse(request, response);
     return DiscoveryContent(
-      response.headers['Content-Type'] ?? acceptHeaderValue,
+      response.headers["Content-Type"] ?? acceptHeaderValue,
       finalResponse.stream,
       request.url,
     );
@@ -317,7 +317,7 @@ final class HttpClient implements ProtocolClient {
 
     yield await _sendDiscoveryRequest(
       request,
-      acceptHeaderValue: 'application/td+json',
+      acceptHeaderValue: "application/td+json",
     );
   }
 
@@ -327,7 +327,7 @@ final class HttpClient implements ProtocolClient {
 
     final encodedLinks = await _sendDiscoveryRequest(
       request,
-      acceptHeaderValue: 'application/link-format',
+      acceptHeaderValue: "application/link-format",
     );
 
     yield encodedLinks;
@@ -336,13 +336,13 @@ final class HttpClient implements ProtocolClient {
   @override
   Future<Content> requestThingDescription(Uri url) async {
     final request = Request(HttpRequestMethod.get.methodName, url);
-    const tdContentType = 'application/td+json';
-    request.headers['Accept'] = tdContentType;
+    const tdContentType = "application/td+json";
+    request.headers["Accept"] = tdContentType;
 
     final response = await _client.send(request);
 
     return Content(
-      response.headers['Content-Type'] ?? tdContentType,
+      response.headers["Content-Type"] ?? tdContentType,
       response.stream,
     );
   }

--- a/lib/src/binding_http/http_client_factory.dart
+++ b/lib/src/binding_http/http_client_factory.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../core/credentials/basic_credentials.dart';
-import '../core/credentials/bearer_credentials.dart';
-import '../core/credentials/callbacks.dart';
-import '../core/protocol_interfaces/protocol_client.dart';
-import '../core/protocol_interfaces/protocol_client_factory.dart';
-import 'http_client.dart';
-import 'http_config.dart';
+import "../core/credentials/basic_credentials.dart";
+import "../core/credentials/bearer_credentials.dart";
+import "../core/credentials/callbacks.dart";
+import "../core/protocol_interfaces/protocol_client.dart";
+import "../core/protocol_interfaces/protocol_client_factory.dart";
+import "http_client.dart";
+import "http_config.dart";
 
 /// A [ProtocolClientFactory] that produces HTTP and HTTPS clients.
 final class HttpClientFactory implements ProtocolClientFactory {
@@ -28,7 +28,7 @@ final class HttpClientFactory implements ProtocolClientFactory {
       _bearerCredentialsCallback;
 
   @override
-  Set<String> get schemes => {'http', 'https'};
+  Set<String> get schemes => {"http", "https"};
 
   @override
   bool destroy() {

--- a/lib/src/binding_http/http_request_method.dart
+++ b/lib/src/binding_http/http_request_method.dart
@@ -1,11 +1,11 @@
-import '../definitions/form.dart';
-import '../definitions/operation_type.dart';
+import "../definitions/form.dart";
+import "../definitions/operation_type.dart";
 
-const _getString = 'GET';
-const _putString = 'PUT';
-const _postString = 'POST';
-const _deleteString = 'DELETE';
-const _patchString = 'PATCH';
+const _getString = "GET";
+const _putString = "PUT";
+const _postString = "POST";
+const _deleteString = "DELETE";
+const _patchString = "PATCH";
 
 /// Defines the available HTTP request methods.
 enum HttpRequestMethod {
@@ -72,7 +72,7 @@ enum HttpRequestMethod {
     Form form,
     OperationType operationType,
   ) {
-    final dynamic formDefinition = form.additionalFields['htv:methodName'];
+    final dynamic formDefinition = form.additionalFields["htv:methodName"];
     if (formDefinition is String) {
       final requestMethod = _requestMethodFromString(formDefinition);
       if (requestMethod != null) {

--- a/lib/src/binding_http/http_security_exception.dart
+++ b/lib/src/binding_http/http_security_exception.dart
@@ -15,6 +15,6 @@ class HttpSecurityException implements Exception {
 
   @override
   String toString() {
-    return 'HttpSecurityException: $message';
+    return "HttpSecurityException: $message";
   }
 }

--- a/lib/src/binding_http/http_server.dart
+++ b/lib/src/binding_http/http_server.dart
@@ -4,17 +4,17 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../core/credentials/callbacks.dart';
-import '../core/protocol_interfaces/protocol_server.dart';
-import '../scripting_api/exposed_thing.dart';
-import 'http_config.dart';
+import "../core/credentials/callbacks.dart";
+import "../core/protocol_interfaces/protocol_server.dart";
+import "../scripting_api/exposed_thing.dart";
+import "http_config.dart";
 
 /// A [ProtocolServer] for the Hypertext Transfer Protocol (HTTP).
 final class HttpServer implements ProtocolServer {
   /// Create a new [HttpServer] from an optional [HttpConfig].
   HttpServer(HttpConfig? httpConfig)
       // TODO(JKRhb): Check if the scheme should be determined differently.
-      : scheme = httpConfig?.secure ?? false ? 'https' : 'http',
+      : scheme = httpConfig?.secure ?? false ? "https" : "http",
         port = _portFromConfig(httpConfig);
 
   @override

--- a/lib/src/binding_mqtt/constants.dart
+++ b/lib/src/binding_mqtt/constants.dart
@@ -8,7 +8,7 @@
 ///
 /// Note that this scheme is not standardized yet, as there is an ongoing debate
 /// about URI schemes in the context of MQTT.
-const mqttUriScheme = 'mqtt';
+const mqttUriScheme = "mqtt";
 
 /// The default port number used for the [mqttUriScheme].
 const defaultMqttPort = 1883;
@@ -17,7 +17,7 @@ const defaultMqttPort = 1883;
 ///
 /// Note that this scheme is not standardized yet, as there is an ongoing debate
 /// about URI schemes in the context of MQTT.
-const mqttSecureUriScheme = 'mqtts';
+const mqttSecureUriScheme = "mqtts";
 
 /// The default port number used for the [mqttSecureUriScheme].
 const defaultMqttSecurePort = 8883;
@@ -27,10 +27,10 @@ const defaultMqttSecurePort = 8883;
 /// Used for resolving MQTT-related compact URIs (CURIEs) in TDs. Note that
 /// the MQTT vocabulary is not standardized yet, so this URI will change in
 /// future versions of this library.
-const mqttContextUri = 'http://www.example.org/mqtt-binding#';
+const mqttContextUri = "http://www.example.org/mqtt-binding#";
 
 /// The default prefix used in MQTT-related compact URIs (CURIEs) in TDs.
-const defaultMqttPrefix = 'mqv';
+const defaultMqttPrefix = "mqv";
 
 /// Default timeout length used for reading properties and discovering TDs.
 const defaultTimeout = Duration(seconds: 10);
@@ -42,10 +42,10 @@ const defaultKeepAlivePeriod = 20;
 /// binding.
 ///
 /// Evaluates to `'application/octet-stream'.
-const defaultContentType = 'application/octet-stream';
+const defaultContentType = "application/octet-stream";
 
 /// Content type used for the Content objects returned by discovery using MQTT.
 ///
 /// Evaluates to `application/td+json`.
 // TODO: Should probably be redefined globally
-const discoveryContentType = 'application/td+json';
+const discoveryContentType = "application/td+json";

--- a/lib/src/binding_mqtt/mqtt_binding_exception.dart
+++ b/lib/src/binding_mqtt/mqtt_binding_exception.dart
@@ -12,5 +12,5 @@ class MqttBindingException implements Exception {
   final String _message;
 
   @override
-  String toString() => 'MqttBindingException: $_message';
+  String toString() => "MqttBindingException: $_message";
 }

--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -4,23 +4,23 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:async';
+import "dart:async";
 
-import 'package:mqtt_client/mqtt_client.dart';
-import 'package:mqtt_client/mqtt_server_client.dart';
-import 'package:typed_data/typed_buffers.dart';
+import "package:mqtt_client/mqtt_client.dart";
+import "package:mqtt_client/mqtt_server_client.dart";
+import "package:typed_data/typed_buffers.dart";
 
-import '../core/content.dart';
-import '../core/credentials/basic_credentials.dart';
-import '../core/credentials/callbacks.dart';
-import '../core/protocol_interfaces/protocol_client.dart';
-import '../definitions/form.dart';
-import '../scripting_api/subscription.dart' as scripting_api;
-import 'constants.dart';
-import 'mqtt_binding_exception.dart';
-import 'mqtt_config.dart';
-import 'mqtt_extensions.dart';
-import 'mqtt_subscription.dart';
+import "../core/content.dart";
+import "../core/credentials/basic_credentials.dart";
+import "../core/credentials/callbacks.dart";
+import "../core/protocol_interfaces/protocol_client.dart";
+import "../definitions/form.dart";
+import "../scripting_api/subscription.dart" as scripting_api;
+import "constants.dart";
+import "mqtt_binding_exception.dart";
+import "mqtt_config.dart";
+import "mqtt_extensions.dart";
+import "mqtt_subscription.dart";
 
 /// [ProtocolClient] for supporting the MQTT protocol.
 ///
@@ -61,13 +61,13 @@ final class MqttClient implements ProtocolClient {
 
     if (form != null) {
       throw MqttBindingException(
-        'Form requires basic authentication but no credentials were provided.',
+        "Form requires basic authentication but no credentials were provided.",
       );
     }
 
     throw MqttBindingException(
-      'Discovery requires basic authentication but no credentials were '
-      'provided.',
+      "Discovery requires basic authentication but no credentials were "
+      "provided.",
     );
   }
 
@@ -92,7 +92,7 @@ final class MqttClient implements ProtocolClient {
     }
 
     if (status?.state != MqttConnectionState.connected) {
-      throw MqttBindingException('Connecting failed');
+      throw MqttBindingException("Connecting failed");
     }
 
     return client;
@@ -129,13 +129,13 @@ final class MqttClient implements ProtocolClient {
     final timer = Timer(
       _mqttConfig.readTimeout,
       () => completer.completeError(
-        TimeoutException('Reading resource $topic failed'),
+        TimeoutException("Reading resource $topic failed"),
       ),
     );
 
     // TODO: Revisit QoS value and subscription check
     if (client.subscribe(topic, qualityOfService) == null) {
-      throw MqttBindingException('Subscription to topic $topic failed');
+      throw MqttBindingException("Subscription to topic $topic failed");
     }
 
     client.updates?.listen((messages) {
@@ -194,7 +194,7 @@ final class MqttClient implements ProtocolClient {
 
     // TODO: Revisit QoS value and subscription check
     if (client.subscribe(topic, qualityOfService) == null) {
-      throw MqttBindingException('Subscription to topic $topic failed');
+      throw MqttBindingException("Subscription to topic $topic failed");
     }
 
     return MqttSubscription(form, client, complete, next: next, error: error);
@@ -206,7 +206,7 @@ final class MqttClient implements ProtocolClient {
     bool disableMulticast = false,
   }) async* {
     final client = await _connect(uri, null);
-    const discoveryTopic = 'wot/td/#';
+    const discoveryTopic = "wot/td/#";
 
     final streamController = StreamController<DiscoveryContent>();
 
@@ -221,7 +221,7 @@ final class MqttClient implements ProtocolClient {
     // TODO: Revisit QoS value and subscription check
     if (client.subscribe(discoveryTopic, MqttQos.atLeastOnce) == null) {
       throw MqttBindingException(
-        'Subscription to topic $discoveryTopic failed',
+        "Subscription to topic $discoveryTopic failed",
       );
     }
 

--- a/lib/src/binding_mqtt/mqtt_client_factory.dart
+++ b/lib/src/binding_mqtt/mqtt_client_factory.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../core/credentials/basic_credentials.dart';
-import '../core/credentials/callbacks.dart';
-import '../core/protocol_interfaces/protocol_client.dart';
-import '../core/protocol_interfaces/protocol_client_factory.dart';
-import 'constants.dart';
-import 'mqtt_client.dart';
-import 'mqtt_config.dart';
+import "../core/credentials/basic_credentials.dart";
+import "../core/credentials/callbacks.dart";
+import "../core/protocol_interfaces/protocol_client.dart";
+import "../core/protocol_interfaces/protocol_client_factory.dart";
+import "constants.dart";
+import "mqtt_client.dart";
+import "mqtt_config.dart";
 
 /// [ProtocolClientFactory] for creating [MqttClient]s.
 final class MqttClientFactory implements ProtocolClientFactory {

--- a/lib/src/binding_mqtt/mqtt_config.dart
+++ b/lib/src/binding_mqtt/mqtt_config.dart
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:meta/meta.dart';
-import 'package:mqtt_client/mqtt_client.dart';
+import "package:meta/meta.dart";
+import "package:mqtt_client/mqtt_client.dart";
 
-import 'constants.dart';
+import "constants.dart";
 
 /// Allows for configuring the behavior of MQTT clients and servers.
 ///

--- a/lib/src/binding_mqtt/mqtt_extensions.dart
+++ b/lib/src/binding_mqtt/mqtt_extensions.dart
@@ -4,18 +4,18 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
-import 'package:mqtt_client/mqtt_client.dart';
-import 'package:mqtt_client/mqtt_server_client.dart';
-import 'package:uuid/uuid.dart';
+import "package:curie/curie.dart";
+import "package:mqtt_client/mqtt_client.dart";
+import "package:mqtt_client/mqtt_server_client.dart";
+import "package:uuid/uuid.dart";
 
-import '../../core.dart';
-import '../definitions/form.dart';
-import '../definitions/security/auto_security_scheme.dart';
-import '../definitions/security/basic_security_scheme.dart';
-import '../definitions/validation/validation_exception.dart';
-import 'constants.dart';
-import 'mqtt_binding_exception.dart';
+import "../../core.dart";
+import "../definitions/form.dart";
+import "../definitions/security/auto_security_scheme.dart";
+import "../definitions/security/basic_security_scheme.dart";
+import "../definitions/validation/validation_exception.dart";
+import "constants.dart";
+import "mqtt_binding_exception.dart";
 
 /// [PrefixMapping] for expanding MQTT Vocabulary terms from compact IRIs.
 final mqttPrefixMapping = PrefixMapping(defaultPrefixValue: mqttContextUri);
@@ -61,7 +61,7 @@ extension MqttUriExtension on Uri {
         return defaultMqttSecurePort;
     }
 
-    throw StateError('MQTT URI scheme $scheme is not supported.');
+    throw StateError("MQTT URI scheme $scheme is not supported.");
   }
 }
 
@@ -80,7 +80,7 @@ extension MqttFormExtension on Form {
     final curieString = mqttPrefixMapping.expandCurie(Curie(reference: term));
 
     final value = additionalFields[curieString] ??
-        additionalFields['$defaultMqttPrefix:$term'];
+        additionalFields["$defaultMqttPrefix:$term"];
 
     if (value is T) {
       return value;
@@ -93,10 +93,10 @@ extension MqttFormExtension on Form {
   ///
   /// Throws an [Exception] if no topic could be retrieved.
   String get topicName {
-    final topic = _obtainVocabularyTerm<String>('topic');
+    final topic = _obtainVocabularyTerm<String>("topic");
 
     if (topic == null) {
-      throw MqttBindingException('MQTT topic was not defined on form.');
+      throw MqttBindingException("MQTT topic was not defined on form.");
     }
 
     return topic;
@@ -106,10 +106,10 @@ extension MqttFormExtension on Form {
   ///
   /// Throws an [Exception] if no topic could be retrieved.
   String get topicFilter {
-    final topic = _obtainVocabularyTerm<String>('filter');
+    final topic = _obtainVocabularyTerm<String>("filter");
 
     if (topic == null) {
-      throw MqttBindingException('MQTT topic was not defined on form.');
+      throw MqttBindingException("MQTT topic was not defined on form.");
     }
 
     return topic;
@@ -118,7 +118,7 @@ extension MqttFormExtension on Form {
   /// Gets the MQTT `retain` value from this [Form] if present.
   ///
   /// Returns `null` otherwise.
-  bool? get retain => _obtainVocabularyTerm<bool>('retain');
+  bool? get retain => _obtainVocabularyTerm<bool>("retain");
 
   bool get _hasBasicSecurityScheme =>
       securityDefinitions.whereType<BasicSecurityScheme>().isNotEmpty;
@@ -130,22 +130,22 @@ extension MqttFormExtension on Form {
   ///
   /// Returns `null` otherwise.
   MqttQos? get qualityOfService {
-    final qosValue = _obtainVocabularyTerm<String>('qos');
+    final qosValue = _obtainVocabularyTerm<String>("qos");
     switch (qosValue) {
-      case 'quality:0':
+      case "quality:0":
         return MqttQos.atMostOnce;
-      case 'quality:1':
+      case "quality:1":
         return MqttQos.atLeastOnce;
-      case 'quality:2':
+      case "quality:2":
         return MqttQos.exactlyOnce;
     }
 
     // TODO: This validation should maybe already happen ealier.
     if (qosValue != null) {
       throw ValidationException(
-        'Encountered unknown QoS value $qosValue. '
-        'in form with href $href of Thing Description with Identifier '
-        '${thingDescription.identifier}.',
+        "Encountered unknown QoS value $qosValue. "
+        "in form with href $href of Thing Description with Identifier "
+        "${thingDescription.identifier}.",
       );
     }
 

--- a/lib/src/binding_mqtt/mqtt_subscription.dart
+++ b/lib/src/binding_mqtt/mqtt_subscription.dart
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:mqtt_client/mqtt_client.dart';
-import 'package:mqtt_client/mqtt_server_client.dart';
+import "package:mqtt_client/mqtt_client.dart";
+import "package:mqtt_client/mqtt_server_client.dart";
 
-import '../core/content.dart';
-import '../definitions/form.dart';
-import '../scripting_api/subscription.dart' as scripting_api;
+import "../core/content.dart";
+import "../definitions/form.dart";
+import "../scripting_api/subscription.dart" as scripting_api;
 
 /// [scripting_api.Subscription] for the MQTT protocol.
 class MqttSubscription implements scripting_api.Subscription {
@@ -24,7 +24,7 @@ class MqttSubscription implements scripting_api.Subscription {
     final updates = _client.updates;
 
     if (updates == null) {
-      throw ArgumentError.notNull('client.updates');
+      throw ArgumentError.notNull("client.updates");
     }
 
     // TODO: Check if this needs to be cleaned up somehow

--- a/lib/src/core/codecs/cbor_codec.dart
+++ b/lib/src/core/codecs/cbor_codec.dart
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:cbor/cbor.dart' as cbor;
+import "package:cbor/cbor.dart" as cbor;
 
-import '../../definitions/data_schema.dart';
-import '../../scripting_api/data_schema_value.dart';
-import 'content_codec.dart';
+import "../../definitions/data_schema.dart";
+import "../../scripting_api/data_schema_value.dart";
+import "content_codec.dart";
 
 /// A [ContentCodec] that encodes and decodes CBOR data.
 class CborCodec extends ContentCodec {

--- a/lib/src/core/codecs/codec_media_type.dart
+++ b/lib/src/core/codecs/codec_media_type.dart
@@ -33,7 +33,7 @@ class CodecMediaType {
   /// `application/json`). The same holds true for parameters like
   /// `charset=utf-8`.
   static CodecMediaType? parse(String mediaType) {
-    final splitMediaType = mediaType.split('/');
+    final splitMediaType = mediaType.split("/");
 
     if (splitMediaType.length < 2) {
       return null;
@@ -45,7 +45,7 @@ class CodecMediaType {
       return null;
     }
 
-    final suffix = splitMediaType[1].split(';').first.split('+').last;
+    final suffix = splitMediaType[1].split(";").first.split("+").last;
 
     if (suffix.isEmpty) {
       return null;

--- a/lib/src/core/codecs/content_codec.dart
+++ b/lib/src/core/codecs/content_codec.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/data_schema.dart';
-import '../../scripting_api/data_schema_value.dart';
+import "../../definitions/data_schema.dart";
+import "../../scripting_api/data_schema_value.dart";
 
 /// Interface for providing a codec for a specific media type.
 abstract class ContentCodec {

--- a/lib/src/core/codecs/json_codec.dart
+++ b/lib/src/core/codecs/json_codec.dart
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
+import "dart:convert";
 
-import '../../definitions/data_schema.dart';
+import "../../definitions/data_schema.dart";
 
-import '../../scripting_api/data_schema_value.dart';
-import 'content_codec.dart';
+import "../../scripting_api/data_schema_value.dart";
+import "content_codec.dart";
 
 /// A [ContentCodec] that encodes and decodes JSON data.
 class JsonCodec extends ContentCodec {

--- a/lib/src/core/codecs/text_codec.dart
+++ b/lib/src/core/codecs/text_codec.dart
@@ -4,14 +4,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
+import "dart:convert";
 
-import '../../definitions/data_schema.dart';
+import "../../definitions/data_schema.dart";
 
-import '../../scripting_api/data_schema_value.dart';
-import 'content_codec.dart';
+import "../../scripting_api/data_schema_value.dart";
+import "content_codec.dart";
 
-const _utf8Coding = 'utf-8';
+const _utf8Coding = "utf-8";
 
 /// A [ContentCodec] that encodes and decodes plain text data.
 class TextCodec extends ContentCodec {
@@ -33,7 +33,7 @@ class TextCodec extends ContentCodec {
       case _utf8Coding:
         return utf8.encode(rawValue);
       default:
-        throw FormatException('Encountered unsupported text coding $coding');
+        throw FormatException("Encountered unsupported text coding $coding");
     }
   }
 
@@ -53,11 +53,11 @@ class TextCodec extends ContentCodec {
       case _utf8Coding:
         return DataSchemaValue.fromString(utf8.decoder.convert(bytes));
       default:
-        throw FormatException('Encountered unsupported text coding $coding');
+        throw FormatException("Encountered unsupported text coding $coding");
     }
   }
 }
 
 extension _ParametersExtension on Map<String, String>? {
-  String get coding => this?['charset']?.toLowerCase() ?? _utf8Coding;
+  String get coding => this?["charset"]?.toLowerCase() ?? _utf8Coding;
 }

--- a/lib/src/core/consumed_thing.dart
+++ b/lib/src/core/consumed_thing.dart
@@ -4,17 +4,17 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../scripting_api.dart' as scripting_api;
-import '../../scripting_api.dart' hide ConsumedThing, InteractionOutput;
-import '../definitions/data_schema.dart';
-import '../definitions/form.dart';
-import '../definitions/interaction_affordances/interaction_affordance.dart';
-import '../definitions/operation_type.dart';
-import '../definitions/thing_description.dart';
-import 'content.dart';
-import 'interaction_output.dart';
-import 'protocol_interfaces/protocol_client.dart';
-import 'servient.dart';
+import "../../scripting_api.dart" as scripting_api;
+import "../../scripting_api.dart" hide ConsumedThing, InteractionOutput;
+import "../definitions/data_schema.dart";
+import "../definitions/form.dart";
+import "../definitions/interaction_affordances/interaction_affordance.dart";
+import "../definitions/operation_type.dart";
+import "../definitions/thing_description.dart";
+import "content.dart";
+import "interaction_output.dart";
+import "protocol_interfaces/protocol_client.dart";
+import "servient.dart";
 
 enum _AffordanceType {
   action,
@@ -32,7 +32,7 @@ class UnexpectedReponseException implements Exception {
   final String message;
 
   @override
-  String toString() => 'UnexpectedReponseException: $message';
+  String toString() => "UnexpectedReponseException: $message";
 }
 
 /// This Exception is thrown when
@@ -44,7 +44,7 @@ class SubscriptionException implements Exception {
   final String message;
 
   @override
-  String toString() => 'SubscriptionException: $message';
+  String toString() => "SubscriptionException: $message";
 }
 
 /// Implementation of the [scripting_api.ConsumedThing] interface.
@@ -99,7 +99,7 @@ class ConsumedThing implements scripting_api.ConsumedThing {
         throw ArgumentError(
           'ConsumedThing "$title" missing formIndex for '
               '$formIndex"',
-          'options.formIndex',
+          "options.formIndex",
         );
       }
     } else {
@@ -108,7 +108,7 @@ class ConsumedThing implements scripting_api.ConsumedThing {
             hasClientFor(form.resolvedHref.scheme) &&
             _supportsOperationType(form, affordanceType, operationType),
         // TODO(JKRhb): Add custom Exception
-        orElse: () => throw Exception('No matching form found!'),
+        orElse: () => throw Exception("No matching form found!"),
       );
       final scheme = foundForm.resolvedHref.scheme;
       client = servient.clientFor(scheme);
@@ -130,8 +130,8 @@ class ConsumedThing implements scripting_api.ConsumedThing {
 
     if (property == null) {
       throw ArgumentError(
-        'ConsumedThing $title does not have property $propertyName',
-        'propertyName',
+        "ConsumedThing $title does not have property $propertyName",
+        "propertyName",
       );
     }
 
@@ -164,8 +164,8 @@ class ConsumedThing implements scripting_api.ConsumedThing {
 
     if (property == null) {
       throw ArgumentError(
-        'ConsumedThing $title does not have property $propertyName',
-        'propertyName',
+        "ConsumedThing $title does not have property $propertyName",
+        "propertyName",
       );
     }
 
@@ -204,8 +204,8 @@ class ConsumedThing implements scripting_api.ConsumedThing {
 
     if (action == null) {
       throw ArgumentError(
-        'ConsumedThing $title does not have action $actionName',
-        'actionName',
+        "ConsumedThing $title does not have action $actionName",
+        "actionName",
       );
     }
 
@@ -233,7 +233,7 @@ class ConsumedThing implements scripting_api.ConsumedThing {
     final response = form.response;
     if (response != null) {
       if (output.type != response.contentType) {
-        throw UnexpectedReponseException('Unexpected type in response');
+        throw UnexpectedReponseException("Unexpected type in response");
       }
     }
 
@@ -258,15 +258,15 @@ class ConsumedThing implements scripting_api.ConsumedThing {
 
     if (property == null) {
       throw ArgumentError(
-        'ConsumedThing $title does not have property $propertyName',
-        'propertyName',
+        "ConsumedThing $title does not have property $propertyName",
+        "propertyName",
       );
     }
 
     if (_observedProperties.containsKey(propertyName)) {
       throw StateError(
         "ConsumedThing '$title' already has a function "
-        'subscribed to $propertyName. You can only observe once',
+        "subscribed to $propertyName. You can only observe once",
       );
     }
 
@@ -409,15 +409,15 @@ class ConsumedThing implements scripting_api.ConsumedThing {
 
     if (event == null) {
       throw ArgumentError(
-        'ConsumedThing $title does not have event $eventName',
-        'eventName',
+        "ConsumedThing $title does not have event $eventName",
+        "eventName",
       );
     }
 
     if (_subscribedEvents.containsKey(eventName)) {
       throw SubscriptionException(
         "ConsumedThing '$title' already has a function "
-        'subscribed to $eventName. You can only subscribe once.',
+        "subscribed to $eventName. You can only subscribe once.",
       );
     }
 

--- a/lib/src/core/content.dart
+++ b/lib/src/core/content.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:typed_data';
+import "dart:typed_data";
 
-import 'package:typed_data/typed_data.dart';
+import "package:typed_data/typed_data.dart";
 
-import '../definitions/data_schema.dart';
-import '../scripting_api/interaction_input.dart';
-import 'content_serdes.dart';
+import "../definitions/data_schema.dart";
+import "../scripting_api/interaction_input.dart";
+import "content_serdes.dart";
 
 /// This class contains binary input or output data and indicates the media
 /// type this data is encoded in.

--- a/lib/src/core/content_serdes.dart
+++ b/lib/src/core/content_serdes.dart
@@ -4,22 +4,22 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:io';
+import "dart:io";
 
-import 'package:http_parser/http_parser.dart';
-import 'package:json_schema/json_schema.dart';
+import "package:http_parser/http_parser.dart";
+import "package:json_schema/json_schema.dart";
 
-import '../definitions/data_schema.dart';
-import '../scripting_api/data_schema_value.dart';
-import 'codecs/cbor_codec.dart';
-import 'codecs/codec_media_type.dart';
-import 'codecs/content_codec.dart';
-import 'codecs/json_codec.dart';
-import 'codecs/text_codec.dart';
-import 'content.dart';
+import "../definitions/data_schema.dart";
+import "../scripting_api/data_schema_value.dart";
+import "codecs/cbor_codec.dart";
+import "codecs/codec_media_type.dart";
+import "codecs/content_codec.dart";
+import "codecs/json_codec.dart";
+import "codecs/text_codec.dart";
+import "content.dart";
 
 /// Defines `application/json` as the default content type.
-const defaultMediaType = 'application/json';
+const defaultMediaType = "application/json";
 
 /// Custom [Exception] that is thrown when Serialization or Deserialization
 /// fails.
@@ -35,7 +35,7 @@ class ContentSerdesException implements Exception {
 
   @override
   String toString() {
-    return 'ContentSerdesException: $message';
+    return "ContentSerdesException: $message";
   }
 }
 
@@ -52,15 +52,15 @@ class ContentSerdes {
   ///
   /// Is initialized with support for JSON, CBOR, and the CoRE Link-Format.
   final _codecs = {
-    CodecMediaType('application', 'json'): JsonCodec(),
-    CodecMediaType('application', 'cbor'): CborCodec(),
-    CodecMediaType('application', 'link-format'): TextCodec(),
-    CodecMediaType('text', 'plain'): TextCodec(),
+    CodecMediaType("application", "json"): JsonCodec(),
+    CodecMediaType("application", "cbor"): CborCodec(),
+    CodecMediaType("application", "link-format"): TextCodec(),
+    CodecMediaType("text", "plain"): TextCodec(),
   };
 
   final Set<String> _offeredMediaTypes = {
-    'application/json',
-    'application/cbor',
+    "application/json",
+    "application/cbor",
   };
 
   /// Parses a [String]-based [mediaType] and adds it to the set of
@@ -73,8 +73,8 @@ class ContentSerdes {
     if (!isSupportedMediaType(parsedMediaType)) {
       throw ArgumentError.value(
         mediaType,
-        'addOfferedMediaType',
-        'Not a supported media type',
+        "addOfferedMediaType",
+        "Not a supported media type",
       );
     }
 
@@ -112,8 +112,8 @@ class ContentSerdes {
     if (parsedMediaType == null) {
       throw ArgumentError.value(
         codecMediaType,
-        'codecMediaType',
-        'Incorrect format',
+        "codecMediaType",
+        "Incorrect format",
       );
     }
 
@@ -126,7 +126,7 @@ class ContentSerdes {
 
   /// Returns a [List] of basic supported media types.
   List<String> get supportedMediaTypes => _codecs.keys
-      .map((e) => '${e.prefix}/${e.suffix}')
+      .map((e) => "${e.prefix}/${e.suffix}")
       .toList(growable: false);
 
   /// Returns a [List] of media types which are offered when a Thing is exposed.
@@ -149,7 +149,7 @@ class ContentSerdes {
 
     // TODO(JKRhb): The process of validating values according to a dataschema
     //              needs to be reworked.
-    const filteredKeys = ['uriVariables'];
+    const filteredKeys = ["uriVariables"];
 
     final filteredDataSchemaJson = dataSchema.rawJson?.entries
         .where((element) => !filteredKeys.contains(element.key));
@@ -158,7 +158,7 @@ class ContentSerdes {
     }
 
     if (dataSchemaValue == null) {
-      throw ContentSerdesException('Expected a defined dataSchemaValue');
+      throw ContentSerdesException("Expected a defined dataSchemaValue");
     }
 
     final schema = JsonSchema.create(
@@ -166,7 +166,7 @@ class ContentSerdes {
       schemaVersion: SchemaVersion.draft7,
     );
     if (!schema.validate(dataSchemaValue.value).isValid) {
-      throw ContentSerdesException('JSON Schema validation failed.');
+      throw ContentSerdesException("JSON Schema validation failed.");
     }
   }
 

--- a/lib/src/core/credentials/ace_credentials.dart
+++ b/lib/src/core/credentials/ace_credentials.dart
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dcaf/dcaf.dart';
+import "package:dcaf/dcaf.dart";
 
-import '../../definitions/security/ace_security_scheme.dart';
-import 'credentials.dart';
+import "../../definitions/security/ace_security_scheme.dart";
+import "credentials.dart";
 
 /// [Credentials] used for the [AceSecurityScheme].
 final class AceCredentials extends Credentials {

--- a/lib/src/core/credentials/apikey_credentials.dart
+++ b/lib/src/core/credentials/apikey_credentials.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/security/apikey_security_scheme.dart';
+import "../../definitions/security/apikey_security_scheme.dart";
 
-import 'credentials.dart';
+import "credentials.dart";
 
 /// [Credentials] used for the [ApiKeySecurityScheme].
 final class ApiKeyCredentials extends Credentials {

--- a/lib/src/core/credentials/basic_credentials.dart
+++ b/lib/src/core/credentials/basic_credentials.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/security/basic_security_scheme.dart';
+import "../../definitions/security/basic_security_scheme.dart";
 
-import 'credentials.dart';
+import "credentials.dart";
 
 /// [Credentials] used for the [BasicSecurityScheme].
 ///

--- a/lib/src/core/credentials/bearer_credentials.dart
+++ b/lib/src/core/credentials/bearer_credentials.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/security/bearer_security_scheme.dart';
+import "../../definitions/security/bearer_security_scheme.dart";
 
-import 'credentials.dart';
+import "credentials.dart";
 
 /// [Credentials] used for the [BearerSecurityScheme].
 final class BearerCredentials extends Credentials {

--- a/lib/src/core/credentials/callbacks.dart
+++ b/lib/src/core/credentials/callbacks.dart
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dcaf/dcaf.dart';
+import "package:dcaf/dcaf.dart";
 
-import '../../definitions/form.dart';
-import 'ace_credentials.dart';
-import 'credentials.dart';
-import 'psk_credentials.dart';
+import "../../definitions/form.dart";
+import "ace_credentials.dart";
+import "credentials.dart";
+import "psk_credentials.dart";
 
 /// Function signature for a synchronous callback for providing client
 /// [PskCredentials] at runtime.

--- a/lib/src/core/credentials/digest_credentials.dart
+++ b/lib/src/core/credentials/digest_credentials.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/security/digest_security_scheme.dart';
-import 'credentials.dart';
+import "../../definitions/security/digest_security_scheme.dart";
+import "credentials.dart";
 
 /// [Credentials] used for the [DigestSecurityScheme].
 final class DigestCredentials extends Credentials {

--- a/lib/src/core/credentials/oauth2_credentials.dart
+++ b/lib/src/core/credentials/oauth2_credentials.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/security/oauth2_security_scheme.dart';
-import 'credentials.dart';
+import "../../definitions/security/oauth2_security_scheme.dart";
+import "credentials.dart";
 
 /// [Credentials] used for the [OAuth2SecurityScheme].
 final class OAuth2Credentials extends Credentials {

--- a/lib/src/core/credentials/psk_credentials.dart
+++ b/lib/src/core/credentials/psk_credentials.dart
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:typed_data';
+import "dart:typed_data";
 
-import '../../definitions/security/psk_security_scheme.dart';
-import 'credentials.dart';
+import "../../definitions/security/psk_security_scheme.dart";
+import "credentials.dart";
 
 /// [Credentials] used for the [PskSecurityScheme].
 final class PskCredentials extends Credentials {

--- a/lib/src/core/exposed_thing.dart
+++ b/lib/src/core/exposed_thing.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions.dart';
-import '../../scripting_api.dart' hide ExposedThing;
-import '../../scripting_api.dart' as scripting_api;
-import '../definitions/interaction_affordances/action.dart';
-import '../definitions/interaction_affordances/event.dart';
-import '../definitions/interaction_affordances/property.dart';
-import 'servient.dart';
+import "../../definitions.dart";
+import "../../scripting_api.dart" hide ExposedThing;
+import "../../scripting_api.dart" as scripting_api;
+import "../definitions/interaction_affordances/action.dart";
+import "../definitions/interaction_affordances/event.dart";
+import "../definitions/interaction_affordances/property.dart";
+import "servient.dart";
 
 /// Implemention of the [scripting_api.ExposedThing] interface.
 class ExposedThing implements scripting_api.ExposedThing {

--- a/lib/src/core/interaction_output.dart
+++ b/lib/src/core/interaction_output.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:typed_data';
+import "dart:typed_data";
 
-import '../../scripting_api.dart' as scripting_api;
-import '../definitions/data_schema.dart';
-import '../definitions/form.dart';
-import 'content.dart';
-import 'content_serdes.dart';
+import "../../scripting_api.dart" as scripting_api;
+import "../definitions/data_schema.dart";
+import "../definitions/form.dart";
+import "content.dart";
+import "content_serdes.dart";
 
 /// Implementation of the [scripting_api.InteractionOutput] interface.
 class InteractionOutput implements scripting_api.InteractionOutput {

--- a/lib/src/core/protocol_interfaces/protocol_client.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/form.dart';
-import '../../scripting_api/subscription.dart';
-import '../content.dart';
+import "../../definitions/form.dart";
+import "../../scripting_api/subscription.dart";
+import "../content.dart";
 
 /// Base class for a Protocol Client.
 abstract interface class ProtocolClient {

--- a/lib/src/core/protocol_interfaces/protocol_client_factory.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client_factory.dart
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'protocol_client.dart';
+import "protocol_client.dart";
 
 /// Base class for a factory that produces [ProtocolClient]s.
 abstract interface class ProtocolClientFactory {

--- a/lib/src/core/protocol_interfaces/protocol_server.dart
+++ b/lib/src/core/protocol_interfaces/protocol_server.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../../scripting_api.dart';
-import '../credentials/callbacks.dart';
+import "../../../scripting_api.dart";
+import "../credentials/callbacks.dart";
 
 /// Base class for a Protocol Server.
 abstract interface class ProtocolServer {

--- a/lib/src/core/servient.dart
+++ b/lib/src/core/servient.dart
@@ -4,20 +4,20 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:uuid/uuid.dart';
+import "package:uuid/uuid.dart";
 
-import '../definitions/interaction_affordances/interaction_affordance.dart';
-import '../definitions/thing_description.dart';
-import '../scripting_api/data_schema_value.dart';
-import 'consumed_thing.dart';
-import 'content_serdes.dart';
-import 'credentials/callbacks.dart';
-import 'exposed_thing.dart';
-import 'protocol_interfaces/protocol_client.dart';
-import 'protocol_interfaces/protocol_client_factory.dart';
-import 'protocol_interfaces/protocol_server.dart';
-import 'thing_discovery.dart';
-import 'wot.dart';
+import "../definitions/interaction_affordances/interaction_affordance.dart";
+import "../definitions/thing_description.dart";
+import "../scripting_api/data_schema_value.dart";
+import "consumed_thing.dart";
+import "content_serdes.dart";
+import "credentials/callbacks.dart";
+import "exposed_thing.dart";
+import "protocol_interfaces/protocol_client.dart";
+import "protocol_interfaces/protocol_client_factory.dart";
+import "protocol_interfaces/protocol_server.dart";
+import "thing_discovery.dart";
+import "wot.dart";
 
 /// Exception that is thrown by a [Servient].
 class ServientException implements Exception {
@@ -27,7 +27,7 @@ class ServientException implements Exception {
   final String _message;
 
   @override
-  String toString() => 'ServientException: $_message';
+  String toString() => "ServientException: $_message";
 }
 
 // TODO(JKRhb): Documentation should be improved.
@@ -133,7 +133,7 @@ class Servient {
   /// `true`.
   bool addThing(ExposedThing thing) {
     const uuid = Uuid();
-    thing.id ??= 'urn:uuid:${uuid.v4()}';
+    thing.id ??= "urn:uuid:${uuid.v4()}";
 
     if (_things.containsKey(thing.id)) {
       return false;
@@ -221,7 +221,7 @@ class Servient {
 
     if (clientFactory == null) {
       throw ServientException(
-        'Servient has no ClientFactory for scheme $scheme',
+        "Servient has no ClientFactory for scheme $scheme",
       );
     }
 
@@ -237,7 +237,7 @@ class Servient {
 
     if (dataSchemaValue is! DataSchemaValue<Map<String, Object?>>) {
       throw DiscoveryException(
-        'Could not parse Thing Description obtained from $url',
+        "Could not parse Thing Description obtained from $url",
       );
     }
 

--- a/lib/src/core/thing_discovery.dart
+++ b/lib/src/core/thing_discovery.dart
@@ -4,18 +4,18 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:async';
+import "dart:async";
 
-import 'package:coap/coap.dart';
-import 'package:collection/collection.dart';
-import 'package:multicast_dns/multicast_dns.dart';
+import "package:coap/coap.dart";
+import "package:collection/collection.dart";
+import "package:multicast_dns/multicast_dns.dart";
 
-import '../../core.dart';
-import '../../scripting_api.dart' as scripting_api;
-import '../definitions/thing_description.dart';
-import '../scripting_api/data_schema_value.dart';
-import '../scripting_api/discovery/discovery_method.dart';
-import 'content.dart';
+import "../../core.dart";
+import "../../scripting_api.dart" as scripting_api;
+import "../definitions/thing_description.dart";
+import "../scripting_api/data_schema_value.dart";
+import "../scripting_api/discovery/discovery_method.dart";
+import "content.dart";
 
 /// Custom [Exception] that is thrown when the discovery process fails.
 class DiscoveryException implements Exception {
@@ -27,7 +27,7 @@ class DiscoveryException implements Exception {
 
   @override
   String toString() {
-    return 'DiscoveryException: $message';
+    return "DiscoveryException: $message";
   }
 }
 
@@ -110,7 +110,7 @@ class ThingDiscovery extends Stream<ThingDescription>
         await _servient.contentSerdes.contentToValue(content, null);
     if (dataSchemaValue is! DataSchemaValue<Map<String, Object?>>) {
       throw DiscoveryException(
-        'Could not parse Thing Description obtained from ${content.sourceUri}',
+        "Could not parse Thing Description obtained from ${content.sourceUri}",
       );
     }
 
@@ -134,7 +134,7 @@ class ThingDiscovery extends Stream<ThingDescription>
 
     if (dataSchemaValue is! DataSchemaValue<String>) {
       throw DiscoveryException(
-        'Could not parse Thing Description obtained from $sourceUri',
+        "Could not parse Thing Description obtained from $sourceUri",
       );
     }
 
@@ -229,26 +229,26 @@ class ThingDiscovery extends Stream<ThingDescription>
   Stream<ThingDescription> _discoverUsingDnsServiceDiscovery(Uri url) async* {
     final dnsName = url.toString();
 
-    if (dnsName.endsWith('local')) {
+    if (dnsName.endsWith("local")) {
       yield* _discoverUsingMdnssd(dnsName);
     } else {
-      throw UnimplementedError('Only mDNS-SD is currently supported!');
+      throw UnimplementedError("Only mDNS-SD is currently supported!");
     }
   }
 
   // TODO(JKRhb): Should be handled in a more robust way
   bool _isUdpDiscovery(String name) {
-    if (name.contains('_udp')) {
+    if (name.contains("_udp")) {
       return true;
     }
 
-    if (name.contains('_tcp')) {
+    if (name.contains("_tcp")) {
       return false;
     }
 
     // TODO(JKRhb): Check if this error message is correct.
     throw DiscoveryException(
-      'Service name $name neither includes _udp nor _tcp',
+      "Service name $name neither includes _udp nor _tcp",
     );
   }
 
@@ -260,8 +260,8 @@ class ThingDiscovery extends Stream<ThingDescription>
         .lookup<TxtResourceRecord>(ResourceRecordQuery.text(domainName))
         .toList();
     final recordsList = txtRecords.firstOrNull?.text
-        .split('\n')
-        .map((property) => property.split('='))
+        .split("\n")
+        .map((property) => property.split("="))
         .where((list) => list.length > 1)
         .map((list) => MapEntry(list[0], list[1]));
 
@@ -277,8 +277,8 @@ class ThingDiscovery extends Stream<ThingDescription>
     await client.start();
 
     final discoveredUris = <Uri>{};
-    final defaultScheme = _isUdpDiscovery(name) ? 'coap' : 'http';
-    const defaultType = 'Thing';
+    final defaultScheme = _isUdpDiscovery(name) ? "coap" : "http";
+    const defaultType = "Thing";
 
     await for (final PtrResourceRecord ptr in client
         .lookup<PtrResourceRecord>(ResourceRecordQuery.serverPointer(name))) {
@@ -295,8 +295,8 @@ class ThingDiscovery extends Stream<ThingDescription>
         final uri = Uri(
           host: srv.target,
           port: srv.port,
-          path: txtRecords['td'],
-          scheme: txtRecords['scheme'] ?? defaultScheme,
+          path: txtRecords["td"],
+          scheme: txtRecords["scheme"] ?? defaultScheme,
         );
 
         final duplicate = !discoveredUris.add(uri);
@@ -305,12 +305,12 @@ class ThingDiscovery extends Stream<ThingDescription>
           continue;
         }
 
-        final type = txtRecords['type'] ?? defaultType;
+        final type = txtRecords["type"] ?? defaultType;
 
         switch (type) {
-          case 'Thing':
+          case "Thing":
             yield* _discoverDirectly(uri);
-          case 'Directory':
+          case "Directory":
             // TODO(JKRhb): Implement directory discovery.
             break;
         }
@@ -340,13 +340,13 @@ extension _UriExtension on Uri {
   /// the parameter name `rt`. If this name should already be in use, it will
   /// not be overridden.
   Uri toLinkFormatDiscoveryUri(String resourceType) {
-    final Map<String, dynamic> newQueryParameters = {'rt': resourceType};
+    final Map<String, dynamic> newQueryParameters = {"rt": resourceType};
     if (queryParameters.isNotEmpty) {
       newQueryParameters.addAll(queryParameters);
     }
 
     return replace(
-      path: _pathOrNull ?? '/.well-known/core',
+      path: _pathOrNull ?? "/.well-known/core",
       queryParameters: newQueryParameters,
     );
   }

--- a/lib/src/core/wot.dart
+++ b/lib/src/core/wot.dart
@@ -4,15 +4,15 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:async';
+import "dart:async";
 
-import '../../scripting_api.dart' as scripting_api;
-import '../definitions/thing_description.dart';
-import '../scripting_api/discovery/discovery_method.dart';
-import 'consumed_thing.dart';
-import 'exposed_thing.dart';
-import 'servient.dart';
-import 'thing_discovery.dart'
+import "../../scripting_api.dart" as scripting_api;
+import "../definitions/thing_description.dart";
+import "../scripting_api/discovery/discovery_method.dart";
+import "consumed_thing.dart";
+import "exposed_thing.dart";
+import "servient.dart";
+import "thing_discovery.dart"
     show DiscoveryException, ThingDiscovery, ThingDiscoveryProcess;
 
 /// This [Exception] is thrown if an error during the consumption of a
@@ -26,8 +26,8 @@ class ThingConsumptionException implements Exception {
 
   @override
   String toString() {
-    return 'ThingConsumptionException: A ConsumedThing with identifier '
-        '$identifier already exists.';
+    return "ThingConsumptionException: A ConsumedThing with identifier "
+        "$identifier already exists.";
   }
 }
 
@@ -42,8 +42,8 @@ class ThingProductionException implements Exception {
 
   @override
   String toString() {
-    return 'ThingProductionException: An ExposedThing with identifier '
-        '$identifier already exists.';
+    return "ThingProductionException: An ExposedThing with identifier "
+        "$identifier already exists.";
   }
 }
 
@@ -108,20 +108,20 @@ class WoT implements scripting_api.WoT {
 
     if (!thingDescription.isValidDirectoryThingDescription) {
       throw DiscoveryException(
-        'Encountered an invalid Directory Thing Description',
+        "Encountered an invalid Directory Thing Description",
       );
     }
 
     final consumedDirectoryThing = await consume(thingDescription);
 
     final interactionOutput =
-        await consumedDirectoryThing.readProperty('things');
+        await consumedDirectoryThing.readProperty("things");
     final rawThingDescriptions = await interactionOutput.value();
 
     if (rawThingDescriptions is! List<Object?>) {
       throw DiscoveryException(
-        'Expected an array of Thing Descriptions but received an '
-        'invalid output instead.',
+        "Expected an array of Thing Descriptions but received an "
+        "invalid output instead.",
       );
     }
 
@@ -141,9 +141,9 @@ extension _DirectoryValidationExtension on ThingDescription {
       return false;
     }
 
-    const discoveryContextUri = 'https://www.w3.org/2022/wot/discovery';
-    const type = 'ThingDirectory';
-    const fullIri = '$discoveryContextUri#$type';
+    const discoveryContextUri = "https://www.w3.org/2022/wot/discovery";
+    const type = "ThingDirectory";
+    const fullIri = "$discoveryContextUri#$type";
 
     if (atTypes.contains(fullIri)) {
       return true;

--- a/lib/src/definitions/additional_expected_response.dart
+++ b/lib/src/definitions/additional_expected_response.dart
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:collection/collection.dart';
-import 'package:curie/curie.dart';
-import 'package:meta/meta.dart';
+import "package:collection/collection.dart";
+import "package:curie/curie.dart";
+import "package:meta/meta.dart";
 
-import 'extensions/json_parser.dart';
+import "extensions/json_parser.dart";
 
 /// Communication metadata describing the expected response message for the
 /// primary response.
@@ -32,9 +32,9 @@ class AdditionalExpectedResponse {
     final Set<String> parsedFields = {};
 
     final contentType =
-        json.parseField<String>('contentType', parsedFields) ?? formContentType;
-    final success = json.parseField<bool>('success', parsedFields);
-    final schema = json.parseField<String>('schema', parsedFields);
+        json.parseField<String>("contentType", parsedFields) ?? formContentType;
+    final success = json.parseField<bool>("success", parsedFields);
+    final schema = json.parseField<String>("schema", parsedFields);
     final additionalFields =
         json.parseAdditionalFields(prefixMapping, parsedFields);
 

--- a/lib/src/definitions/data_schema.dart
+++ b/lib/src/definitions/data_schema.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import 'extensions/json_parser.dart';
+import "extensions/json_parser.dart";
 
 /// Metadata that describes the data format used. It can be used for validation.
 ///
@@ -59,43 +59,43 @@ class DataSchema {
     Set<String>? parsedFields,
   ]) {
     parsedFields = parsedFields ?? {};
-    final atType = json.parseArrayField<String>('@type', parsedFields);
-    final title = json.parseField<String>('title', parsedFields);
-    final titles = json.parseMapField<String>('titles', parsedFields);
-    final description = json.parseField<String>('description', parsedFields);
+    final atType = json.parseArrayField<String>("@type", parsedFields);
+    final title = json.parseField<String>("title", parsedFields);
+    final titles = json.parseMapField<String>("titles", parsedFields);
+    final description = json.parseField<String>("description", parsedFields);
     final descriptions =
-        json.parseMapField<String>('descriptions', parsedFields);
-    final constant = json.parseField<Object>('constant', parsedFields);
-    final defaultValue = json.parseField<Object>('default', parsedFields);
-    final enumeration = json.parseField<List<Object>>('enum', parsedFields);
-    final readOnly = json.parseField<bool>('readOnly', parsedFields);
-    final writeOnly = json.parseField<bool>('writeOnly', parsedFields);
-    final format = json.parseField<String>('format', parsedFields);
-    final unit = json.parseField<String>('unit', parsedFields);
-    final type = json.parseField<String>('type', parsedFields);
-    final minimum = json.parseField<num>('minimum', parsedFields);
+        json.parseMapField<String>("descriptions", parsedFields);
+    final constant = json.parseField<Object>("constant", parsedFields);
+    final defaultValue = json.parseField<Object>("default", parsedFields);
+    final enumeration = json.parseField<List<Object>>("enum", parsedFields);
+    final readOnly = json.parseField<bool>("readOnly", parsedFields);
+    final writeOnly = json.parseField<bool>("writeOnly", parsedFields);
+    final format = json.parseField<String>("format", parsedFields);
+    final unit = json.parseField<String>("unit", parsedFields);
+    final type = json.parseField<String>("type", parsedFields);
+    final minimum = json.parseField<num>("minimum", parsedFields);
     final exclusiveMinimum =
-        json.parseField<num>('exclusiveMinimum', parsedFields);
-    final maximum = json.parseField<num>('minimum', parsedFields);
+        json.parseField<num>("exclusiveMinimum", parsedFields);
+    final maximum = json.parseField<num>("minimum", parsedFields);
     final exclusiveMaximum =
-        json.parseField<num>('exclusiveMaximum', parsedFields);
-    final multipleOf = json.parseField<num>('multipleOf', parsedFields);
+        json.parseField<num>("exclusiveMaximum", parsedFields);
+    final multipleOf = json.parseField<num>("multipleOf", parsedFields);
     final items =
-        json.parseDataSchemaArrayField('items', prefixMapping, parsedFields);
-    final minItems = json.parseField<int>('minItems', parsedFields);
-    final maxItems = json.parseField<int>('maxItems', parsedFields);
-    final required = json.parseField<List<String>>('required', parsedFields);
-    final minLength = json.parseField<int>('minLength', parsedFields);
-    final maxLength = json.parseField<int>('maxLength', parsedFields);
-    final pattern = json.parseField<String>('pattern', parsedFields);
+        json.parseDataSchemaArrayField("items", prefixMapping, parsedFields);
+    final minItems = json.parseField<int>("minItems", parsedFields);
+    final maxItems = json.parseField<int>("maxItems", parsedFields);
+    final required = json.parseField<List<String>>("required", parsedFields);
+    final minLength = json.parseField<int>("minLength", parsedFields);
+    final maxLength = json.parseField<int>("maxLength", parsedFields);
+    final pattern = json.parseField<String>("pattern", parsedFields);
     final contentEncoding =
-        json.parseField<String>('contentEncoding', parsedFields);
+        json.parseField<String>("contentEncoding", parsedFields);
     final contentMediaType =
-        json.parseField<String>('contentMediaType', parsedFields);
+        json.parseField<String>("contentMediaType", parsedFields);
     final oneOf =
-        json.parseDataSchemaArrayField('oneOf', prefixMapping, parsedFields);
+        json.parseDataSchemaArrayField("oneOf", prefixMapping, parsedFields);
     final properties =
-        json.parseDataSchemaMapField('properties', prefixMapping, parsedFields);
+        json.parseDataSchemaMapField("properties", prefixMapping, parsedFields);
     final additionalFields =
         json.parseAdditionalFields(prefixMapping, parsedFields);
 

--- a/lib/src/definitions/expected_response.dart
+++ b/lib/src/definitions/expected_response.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import 'extensions/json_parser.dart';
+import "extensions/json_parser.dart";
 
 /// Communication metadata describing the expected response message for the
 /// primary response.
@@ -15,7 +15,7 @@ class ExpectedResponse {
   ExpectedResponse(this.contentType, {Map<String, dynamic>? additionalFields})
       : additionalFields = Map.fromEntries(
           additionalFields?.entries
-                  .where((element) => element.key != 'contentType') ??
+                  .where((element) => element.key != "contentType") ??
               [],
         );
 
@@ -27,7 +27,7 @@ class ExpectedResponse {
     final Set<String> parsedFields = {};
 
     final contentType =
-        json.parseRequiredField<String>('contentType', parsedFields);
+        json.parseRequiredField<String>("contentType", parsedFields);
     final additionalFields =
         json.parseAdditionalFields(prefixMapping, parsedFields);
 

--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -1,34 +1,34 @@
-import 'package:collection/collection.dart';
-import 'package:curie/curie.dart';
+import "package:collection/collection.dart";
+import "package:curie/curie.dart";
 
-import '../additional_expected_response.dart';
-import '../data_schema.dart';
-import '../expected_response.dart';
-import '../form.dart';
-import '../interaction_affordances/action.dart';
-import '../interaction_affordances/event.dart';
-import '../interaction_affordances/interaction_affordance.dart';
-import '../interaction_affordances/property.dart';
-import '../link.dart';
-import '../security/ace_security_scheme.dart';
-import '../security/apikey_security_scheme.dart';
-import '../security/auto_security_scheme.dart';
-import '../security/basic_security_scheme.dart';
-import '../security/bearer_security_scheme.dart';
-import '../security/combo_security_scheme.dart';
-import '../security/digest_security_scheme.dart';
-import '../security/no_security_scheme.dart';
-import '../security/oauth2_security_scheme.dart';
-import '../security/psk_security_scheme.dart';
-import '../security/security_scheme.dart';
-import '../thing_description.dart';
-import '../validation/validation_exception.dart';
-import '../version_info.dart';
+import "../additional_expected_response.dart";
+import "../data_schema.dart";
+import "../expected_response.dart";
+import "../form.dart";
+import "../interaction_affordances/action.dart";
+import "../interaction_affordances/event.dart";
+import "../interaction_affordances/interaction_affordance.dart";
+import "../interaction_affordances/property.dart";
+import "../link.dart";
+import "../security/ace_security_scheme.dart";
+import "../security/apikey_security_scheme.dart";
+import "../security/auto_security_scheme.dart";
+import "../security/basic_security_scheme.dart";
+import "../security/bearer_security_scheme.dart";
+import "../security/combo_security_scheme.dart";
+import "../security/digest_security_scheme.dart";
+import "../security/no_security_scheme.dart";
+import "../security/oauth2_security_scheme.dart";
+import "../security/psk_security_scheme.dart";
+import "../security/security_scheme.dart";
+import "../thing_description.dart";
+import "../validation/validation_exception.dart";
+import "../version_info.dart";
 
 const _validTdContextValues = [
-  'https://www.w3.org/2019/wot/td/v1',
-  'https://www.w3.org/2022/wot/td/v1.1',
-  'http://www.w3.org/ns/td',
+  "https://www.w3.org/2019/wot/td/v1",
+  "https://www.w3.org/2022/wot/td/v1.1",
+  "http://www.w3.org/ns/td",
 ];
 
 /// Extension for parsing fields of JSON objects.
@@ -109,8 +109,8 @@ extension ParseField on Map<String, dynamic> {
 
     if (fieldValue is! T) {
       throw ValidationException(
-        'Value for field $name has wrong data type or is missing. '
-        'Expected ${T.runtimeType}, got ${fieldValue.runtimeType}.',
+        "Value for field $name has wrong data type or is missing. "
+        "Expected ${T.runtimeType}, got ${fieldValue.runtimeType}.",
       );
     }
 
@@ -257,7 +257,7 @@ extension ParseField on Map<String, dynamic> {
     Set<String>? parsedFields, [
     InteractionAffordance? interactionAffordance,
   ]) {
-    final fieldValue = parseField('forms', parsedFields);
+    final fieldValue = parseField("forms", parsedFields);
 
     if (fieldValue is! List) {
       return null;
@@ -311,7 +311,7 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String>? parsedFields,
   ) {
-    final fieldValue = parseField('links', parsedFields);
+    final fieldValue = parseField("links", parsedFields);
 
     if (fieldValue is! List) {
       return null;
@@ -332,7 +332,7 @@ extension ParseField on Map<String, dynamic> {
     Set<String> parsedFields,
   ) {
     final fieldValue =
-        parseMapField<dynamic>('securityDefinitions', parsedFields);
+        parseMapField<dynamic>("securityDefinitions", parsedFields);
 
     if (fieldValue == null) {
       return null;
@@ -357,28 +357,28 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
   ) {
-    final scheme = parseRequiredField('scheme', parsedFields);
+    final scheme = parseRequiredField("scheme", parsedFields);
 
     switch (scheme) {
-      case 'auto':
+      case "auto":
         return AutoSecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'basic':
+      case "basic":
         return BasicSecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'bearer':
+      case "bearer":
         return BearerSecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'combo':
+      case "combo":
         return ComboSecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'nosec':
+      case "nosec":
         return NoSecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'psk':
+      case "psk":
         return PskSecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'digest':
+      case "digest":
         return DigestSecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'apikey':
+      case "apikey":
         return ApiKeySecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'oauth2':
+      case "oauth2":
         return OAuth2SecurityScheme.fromJson(this, prefixMapping, parsedFields);
-      case 'ace:ACESecurityScheme':
+      case "ace:ACESecurityScheme":
         return AceSecurityScheme.fromJson(this, prefixMapping, parsedFields);
     }
 
@@ -393,7 +393,7 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String>? parsedFields,
   ) {
-    final fieldValue = parseMapField<dynamic>('properties', parsedFields);
+    final fieldValue = parseMapField<dynamic>("properties", parsedFields);
 
     if (fieldValue == null) {
       return null;
@@ -420,7 +420,7 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String>? parsedFields,
   ) {
-    final fieldValue = parseMapField<dynamic>('actions', parsedFields);
+    final fieldValue = parseMapField<dynamic>("actions", parsedFields);
 
     if (fieldValue == null) {
       return null;
@@ -447,7 +447,7 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String>? parsedFields,
   ) {
-    final fieldValue = parseMapField<dynamic>('events', parsedFields);
+    final fieldValue = parseMapField<dynamic>("events", parsedFields);
 
     if (fieldValue == null) {
       return null;
@@ -473,7 +473,7 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String>? parsedFields,
   ) {
-    final fieldValue = parseMapField<dynamic>('response', parsedFields);
+    final fieldValue = parseMapField<dynamic>("response", parsedFields);
 
     if (fieldValue == null) {
       return null;
@@ -492,7 +492,7 @@ extension ParseField on Map<String, dynamic> {
     Set<String>? parsedFields,
   ) {
     final fieldValue = parseArrayField<Map<String, dynamic>>(
-      'additionalResponses',
+      "additionalResponses",
       parsedFields,
     );
 
@@ -518,7 +518,7 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String>? parsedFields,
   ) {
-    final fieldValue = parseMapField<dynamic>('version', parsedFields);
+    final fieldValue = parseMapField<dynamic>("version", parsedFields);
 
     if (fieldValue == null) {
       return null;
@@ -565,8 +565,8 @@ extension ParseField on Map<String, dynamic> {
   }
 
   static String _expandCurieKey(String key, PrefixMapping prefixMapping) {
-    if (key.contains(':')) {
-      final prefix = key.split(':')[0];
+    if (key.contains(":")) {
+      final prefix = key.split(":")[0];
       if (prefixMapping.getPrefixValue(prefix) != null) {
         return prefixMapping.expandCurieString(key);
       }
@@ -575,8 +575,8 @@ extension ParseField on Map<String, dynamic> {
   }
 
   static dynamic _expandCurieValue(dynamic value, PrefixMapping prefixMapping) {
-    if (value is String && value.contains(':')) {
-      final prefix = value.split(':')[0];
+    if (value is String && value.contains(":")) {
+      final prefix = value.split(":")[0];
       if (prefixMapping.getPrefixValue(prefix) != null) {
         return prefixMapping.expandCurieString(value);
       }
@@ -598,7 +598,7 @@ extension ParseField on Map<String, dynamic> {
     Set<String>? parsedFields, {
     bool firstEntry = true,
   }) {
-    final fieldValue = parseField('@context', parsedFields);
+    final fieldValue = parseField("@context", parsedFields);
 
     return _parseContext(fieldValue, prefixMapping);
   }
@@ -646,7 +646,7 @@ List<ContextEntry> _parseContext(
             throw ContextValidationException(value.runtimeType);
           }
 
-          if (!key.startsWith('@') && Uri.tryParse(value) != null) {
+          if (!key.startsWith("@") && Uri.tryParse(value) != null) {
             prefixMapping.addPrefix(key, value);
           }
           return (key: key, value: value);
@@ -663,7 +663,7 @@ class ContextValidationException extends ValidationException {
   /// [runtimeType].
   ContextValidationException(Type runtimeType)
       : super(
-          'Excepted either a String or a Map<String, String> '
-          'as @context entry, got $runtimeType instead.',
+          "Excepted either a String or a Map<String, String> "
+          "as @context entry, got $runtimeType instead.",
         );
 }

--- a/lib/src/definitions/form.dart
+++ b/lib/src/definitions/form.dart
@@ -4,21 +4,21 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
-import 'package:json_schema/json_schema.dart';
-import 'package:uri/uri.dart';
+import "package:curie/curie.dart";
+import "package:json_schema/json_schema.dart";
+import "package:uri/uri.dart";
 
-import '../../dart_wot.dart';
-import 'additional_expected_response.dart';
-import 'expected_response.dart';
-import 'extensions/json_parser.dart';
-import 'interaction_affordances/action.dart';
-import 'interaction_affordances/event.dart';
-import 'interaction_affordances/interaction_affordance.dart';
-import 'interaction_affordances/property.dart';
-import 'operation_type.dart';
-import 'security/security_scheme.dart';
-import 'validation/validation_exception.dart';
+import "../../dart_wot.dart";
+import "additional_expected_response.dart";
+import "expected_response.dart";
+import "extensions/json_parser.dart";
+import "interaction_affordances/action.dart";
+import "interaction_affordances/event.dart";
+import "interaction_affordances/interaction_affordance.dart";
+import "interaction_affordances/property.dart";
+import "operation_type.dart";
+import "security/security_scheme.dart";
+import "validation/validation_exception.dart";
 
 /// Contains the information needed for performing interactions with a Thing.
 class Form {
@@ -29,7 +29,7 @@ class Form {
     this.href,
     this.thingDescription, {
     this.interactionAffordance,
-    this.contentType = 'application/json',
+    this.contentType = "application/json",
     this.contentCoding,
     this.subprotocol,
     this.security,
@@ -55,20 +55,20 @@ class Form {
     InteractionAffordance? interactionAffordance,
   ]) {
     final Set<String> parsedFields = {};
-    final href = json.parseRequiredUriField('href', parsedFields);
+    final href = json.parseRequiredUriField("href", parsedFields);
 
-    final subprotocol = json.parseField<String>('subprotocol', parsedFields);
+    final subprotocol = json.parseField<String>("subprotocol", parsedFields);
 
-    final List<String>? op = json.parseArrayField<String>('op', parsedFields);
+    final List<String>? op = json.parseArrayField<String>("op", parsedFields);
 
-    final contentType = json.parseField<String>('contentType', parsedFields) ??
-        'application/json';
+    final contentType = json.parseField<String>("contentType", parsedFields) ??
+        "application/json";
 
     final contentCoding =
-        json.parseField<String>('contentCoding', parsedFields);
+        json.parseField<String>("contentCoding", parsedFields);
 
-    final security = json.parseArrayField<String>('security', parsedFields);
-    final scopes = json.parseArrayField<String>('scopes', parsedFields);
+    final security = json.parseArrayField<String>("security", parsedFields);
+    final scopes = json.parseArrayField<String>("scopes", parsedFields);
     final response = json.parseExpectedResponse(prefixMapping, parsedFields);
 
     final additionalResponses = json.parseAdditionalExpectedResponse(
@@ -123,7 +123,7 @@ class Form {
   final List<OperationType> op;
 
   /// The [contentType] supported by this [Form].
-  String contentType = 'application/json';
+  String contentType = "application/json";
 
   /// The content coding supported by this [Form].
   ///
@@ -167,9 +167,9 @@ class Form {
 
       if (securityDefinition == null) {
         throw ValidationException(
-          'Form requires a security definition with '
-          'key $securityKey, but the Thing Description does not define a '
-          'security definition with such a key!',
+          "Form requires a security definition with "
+          "key $securityKey, but the Thing Description does not define a "
+          "security definition with such a key!",
         );
       }
 
@@ -189,7 +189,7 @@ class Form {
     } else {
       throw ValidationException(
         "The form's $href is not an absolute URI, "
-        'but the Thing Description does not provide a base field!',
+        "but the Thing Description does not provide a base field!",
       );
     }
   }
@@ -222,8 +222,8 @@ class Form {
     }
 
     throw StateError(
-      'Encountered unknown InteractionAffordance '
-      '${interactionAffordance.runtimeType}.',
+      "Encountered unknown InteractionAffordance "
+      "${interactionAffordance.runtimeType}.",
     );
   }
 
@@ -255,8 +255,8 @@ class Form {
 
     if (missingTdDefinitions.isNotEmpty) {
       throw UriVariableException(
-        '$missingTdDefinitions do not have defined '
-        'uriVariables in the TD',
+        "$missingTdDefinitions do not have defined "
+        "uriVariables in the TD",
       );
     }
 
@@ -265,8 +265,8 @@ class Form {
 
     if (missingUserInput.isNotEmpty) {
       throw UriVariableException(
-        '$missingUserInput did not have defined '
-        'Values in the provided InteractionOptions.',
+        "$missingUserInput did not have defined "
+        "Values in the provided InteractionOptions.",
       );
     }
 
@@ -277,20 +277,20 @@ class Form {
       final value = affordanceUriVariable.value;
 
       if (value == null) {
-        throw ValidationException('Missing schema for URI variable $key');
+        throw ValidationException("Missing schema for URI variable $key");
       }
 
       final schema = JsonSchema.create(value);
       final result = schema.validate(uriVariables[key]);
 
       if (!result.isValid) {
-        throw ValidationException('Invalid type for URI variable $key');
+        throw ValidationException("Invalid type for URI variable $key");
       }
     }
   }
 
   List<String> _filterUriVariables(Uri href) {
-    final regex = RegExp('{[?+#./;&]?([^}]*)}');
+    final regex = RegExp("{[?+#./;&]?([^}]*)}");
     final decodedUri = Uri.decodeFull(href.toString());
     return regex
         .allMatches(decodedUri)
@@ -352,6 +352,6 @@ class UriVariableException implements Exception {
 
   @override
   String toString() {
-    return 'UriVariableException: $message';
+    return "UriVariableException: $message";
   }
 }

--- a/lib/src/definitions/interaction_affordances/action.dart
+++ b/lib/src/definitions/interaction_affordances/action.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
-import 'package:meta/meta.dart';
+import "package:curie/curie.dart";
+import "package:meta/meta.dart";
 
-import '../data_schema.dart';
-import '../extensions/json_parser.dart';
-import '../thing_description.dart';
-import 'interaction_affordance.dart';
+import "../data_schema.dart";
+import "../extensions/json_parser.dart";
+import "../thing_description.dart";
+import "interaction_affordance.dart";
 
 /// Class representing an [Action] Affordance in a Thing Description.
 @immutable
@@ -39,22 +39,22 @@ class Action extends InteractionAffordance {
   ) {
     final Set<String> parsedFields = {};
 
-    final title = json.parseField<String>('title', parsedFields);
-    final titles = json.parseMapField<String>('titles', parsedFields);
-    final description = json.parseField<String>('description', parsedFields);
+    final title = json.parseField<String>("title", parsedFields);
+    final titles = json.parseMapField<String>("titles", parsedFields);
+    final description = json.parseField<String>("description", parsedFields);
     final descriptions =
-        json.parseMapField<String>('descriptions', parsedFields);
+        json.parseMapField<String>("descriptions", parsedFields);
     final uriVariables =
-        json.parseMapField<dynamic>('uriVariables', parsedFields);
+        json.parseMapField<dynamic>("uriVariables", parsedFields);
 
-    final safe = json.parseField<bool>('safe', parsedFields) ?? false;
+    final safe = json.parseField<bool>("safe", parsedFields) ?? false;
     final idempotent =
-        json.parseField<bool>('idempotent', parsedFields) ?? false;
-    final synchronous = json.parseField<bool>('synchronous', parsedFields);
+        json.parseField<bool>("idempotent", parsedFields) ?? false;
+    final synchronous = json.parseField<bool>("synchronous", parsedFields);
     final input =
-        json.parseDataSchemaField('input', prefixMapping, parsedFields);
+        json.parseDataSchemaField("input", prefixMapping, parsedFields);
     final output =
-        json.parseDataSchemaField('output', prefixMapping, parsedFields);
+        json.parseDataSchemaField("output", prefixMapping, parsedFields);
 
     final action = Action(
       thingDescription,

--- a/lib/src/definitions/interaction_affordances/event.dart
+++ b/lib/src/definitions/interaction_affordances/event.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
-import 'package:meta/meta.dart';
+import "package:curie/curie.dart";
+import "package:meta/meta.dart";
 
-import '../data_schema.dart';
-import '../extensions/json_parser.dart';
-import '../thing_description.dart';
-import 'interaction_affordance.dart';
+import "../data_schema.dart";
+import "../extensions/json_parser.dart";
+import "../thing_description.dart";
+import "interaction_affordance.dart";
 
 /// Class representing an [Event] Affordance in a Thing Description.
 @immutable
@@ -37,19 +37,19 @@ class Event extends InteractionAffordance {
   ) {
     final Set<String> parsedFields = {};
 
-    final title = json.parseField<String>('title', parsedFields);
-    final titles = json.parseMapField<String>('titles', parsedFields);
-    final description = json.parseField<String>('description', parsedFields);
+    final title = json.parseField<String>("title", parsedFields);
+    final titles = json.parseMapField<String>("titles", parsedFields);
+    final description = json.parseField<String>("description", parsedFields);
     final descriptions =
-        json.parseMapField<String>('descriptions', parsedFields);
+        json.parseMapField<String>("descriptions", parsedFields);
     final uriVariables =
-        json.parseMapField<dynamic>('uriVariables', parsedFields);
+        json.parseMapField<dynamic>("uriVariables", parsedFields);
 
     final subscription =
-        json.parseDataSchemaField('subscription', prefixMapping, parsedFields);
-    final data = json.parseDataSchemaField('data', prefixMapping, parsedFields);
+        json.parseDataSchemaField("subscription", prefixMapping, parsedFields);
+    final data = json.parseDataSchemaField("data", prefixMapping, parsedFields);
     final cancellation =
-        json.parseDataSchemaField('cancellation', prefixMapping, parsedFields);
+        json.parseDataSchemaField("cancellation", prefixMapping, parsedFields);
 
     final event = Event(
       thingDescription,

--- a/lib/src/definitions/interaction_affordances/interaction_affordance.dart
+++ b/lib/src/definitions/interaction_affordances/interaction_affordance.dart
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:meta/meta.dart';
+import "package:meta/meta.dart";
 
-import '../form.dart';
-import '../thing_description.dart';
+import "../form.dart";
+import "../thing_description.dart";
 
 /// Base class for Interaction Affordances (Properties, Actions, and Events).
 @immutable

--- a/lib/src/definitions/interaction_affordances/property.dart
+++ b/lib/src/definitions/interaction_affordances/property.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
-import 'package:meta/meta.dart';
+import "package:curie/curie.dart";
+import "package:meta/meta.dart";
 
-import '../data_schema.dart';
-import '../extensions/json_parser.dart';
-import '../thing_description.dart';
-import 'interaction_affordance.dart';
+import "../data_schema.dart";
+import "../extensions/json_parser.dart";
+import "../thing_description.dart";
+import "interaction_affordance.dart";
 
 /// Class representing a [Property] Affordance in a Thing Description.
 @immutable
@@ -32,9 +32,9 @@ class Property extends InteractionAffordance implements DataSchema {
   ) {
     final Set<String> parsedFields = {};
     final observable =
-        json.parseField<bool>('observable', parsedFields) ?? false;
+        json.parseField<bool>("observable", parsedFields) ?? false;
     final uriVariables =
-        json.parseMapField<dynamic>('uriVariables', parsedFields);
+        json.parseMapField<dynamic>("uriVariables", parsedFields);
     final dataSchema = DataSchema.fromJson(json, prefixMapping, parsedFields);
 
     final property = Property(

--- a/lib/src/definitions/link.dart
+++ b/lib/src/definitions/link.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import 'extensions/json_parser.dart';
+import "extensions/json_parser.dart";
 
 /// Represents an element of the `links` array in a Thing Description.
 ///
@@ -34,13 +34,13 @@ class Link {
   Link.fromJson(Map<String, dynamic> json, PrefixMapping prefixMapping) {
     final Set<String> parsedFields = {};
 
-    href = json.parseRequiredUriField('href', parsedFields);
-    type = json.parseField<String>('@type', parsedFields);
-    rel = json.parseField<String>('rel', parsedFields);
+    href = json.parseRequiredUriField("href", parsedFields);
+    type = json.parseField<String>("@type", parsedFields);
+    rel = json.parseField<String>("rel", parsedFields);
     anchor =
-        Uri.tryParse(json.parseField<String>('anchor', parsedFields) ?? '');
-    sizes = json.parseField<String>('sizes', parsedFields);
-    hreflang = json.parseArrayField<String>('hreflang', parsedFields);
+        Uri.tryParse(json.parseField<String>("anchor", parsedFields) ?? "");
+    sizes = json.parseField<String>("sizes", parsedFields);
+    hreflang = json.parseArrayField<String>("hreflang", parsedFields);
 
     additionalFields
         .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));

--- a/lib/src/definitions/operation_type.dart
+++ b/lib/src/definitions/operation_type.dart
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'validation/validation_exception.dart';
+import "validation/validation_exception.dart";
 
 /// Enumeration for the possible WoT operation types.
 ///
@@ -55,7 +55,7 @@ enum OperationType {
 
     if (operationType == null) {
       throw ValidationException(
-        'Encountered unknown OperationType $stringValue.',
+        "Encountered unknown OperationType $stringValue.",
       );
     }
 

--- a/lib/src/definitions/security/ace_security_scheme.dart
+++ b/lib/src/definitions/security/ace_security_scheme.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
+import "../extensions/json_parser.dart";
 
-import 'security_scheme.dart';
+import "security_scheme.dart";
 
-const _schemeName = 'ace:ACESecurityScheme';
+const _schemeName = "ace:ACESecurityScheme";
 
 /// Experimental ACE Security Scheme.
 final class AceSecurityScheme extends SecurityScheme {
@@ -32,10 +32,10 @@ final class AceSecurityScheme extends SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : as = json.parseField<String>('ace:as', parsedFields),
-        cnonce = json.parseField<bool>('ace:cnonce', parsedFields),
-        audience = json.parseField<String>('ace:audience', parsedFields),
-        scopes = json.parseArrayField<String>('ace:scopes', parsedFields),
+  )   : as = json.parseField<String>("ace:as", parsedFields),
+        cnonce = json.parseField<bool>("ace:cnonce", parsedFields),
+        audience = json.parseField<String>("ace:audience", parsedFields),
+        scopes = json.parseArrayField<String>("ace:scopes", parsedFields),
         super.fromJson(
           _schemeName,
           json,

--- a/lib/src/definitions/security/apikey_security_scheme.dart
+++ b/lib/src/definitions/security/apikey_security_scheme.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
-import 'security_scheme.dart';
+import "../extensions/json_parser.dart";
+import "security_scheme.dart";
 
-const _defaultInValue = 'query';
-const _schemeName = 'apikey';
+const _defaultInValue = "query";
+const _schemeName = "apikey";
 
 /// API key authentication security configuration identified by the Vocabulary
 /// Term `apikey`.
@@ -32,8 +32,8 @@ final class ApiKeySecurityScheme extends SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>('name', parsedFields),
-        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
+  )   : name = json.parseField<String>("name", parsedFields),
+        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
         super.fromJson(
           _schemeName,
           json,

--- a/lib/src/definitions/security/auto_security_scheme.dart
+++ b/lib/src/definitions/security/auto_security_scheme.dart
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import 'security_scheme.dart';
+import "security_scheme.dart";
 
-const _schemeName = 'auto';
+const _schemeName = "auto";
 
 /// An automatic security configuration identified by the
 /// vocabulary term `auto`.

--- a/lib/src/definitions/security/basic_security_scheme.dart
+++ b/lib/src/definitions/security/basic_security_scheme.dart
@@ -4,14 +4,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
-import 'security_scheme.dart';
+import "../extensions/json_parser.dart";
+import "security_scheme.dart";
 
-const _defaultInValue = 'header';
+const _defaultInValue = "header";
 
-const _schemeName = 'basic';
+const _schemeName = "basic";
 
 /// Basic Authentication security configuration identified by the Vocabulary
 /// Term `basic`.
@@ -32,8 +32,8 @@ final class BasicSecurityScheme extends SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>('name', parsedFields),
-        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
+  )   : name = json.parseField<String>("name", parsedFields),
+        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
         super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// Name for query, header, cookie, or uri parameters.

--- a/lib/src/definitions/security/bearer_security_scheme.dart
+++ b/lib/src/definitions/security/bearer_security_scheme.dart
@@ -4,16 +4,16 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
-import 'security_scheme.dart';
+import "../extensions/json_parser.dart";
+import "security_scheme.dart";
 
-const _defaultInValue = 'header';
-const _defaultAlgValue = 'ES256';
-const _defaultFormatValue = 'jwt';
+const _defaultInValue = "header";
+const _defaultAlgValue = "ES256";
+const _defaultFormatValue = "jwt";
 
-const _schemeName = 'bearer';
+const _schemeName = "bearer";
 
 /// Bearer Token security configuration identified by the Vocabulary Term
 /// `bearer`.
@@ -37,12 +37,12 @@ final class BearerSecurityScheme extends SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>('name', parsedFields),
-        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
-        format = json.parseField<String>('format', parsedFields) ??
+  )   : name = json.parseField<String>("name", parsedFields),
+        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
+        format = json.parseField<String>("format", parsedFields) ??
             _defaultFormatValue,
-        alg = json.parseField<String>('alg', parsedFields) ?? _defaultAlgValue,
-        authorization = json.parseField<String>('authorization', parsedFields),
+        alg = json.parseField<String>("alg", parsedFields) ?? _defaultAlgValue,
+        authorization = json.parseField<String>("authorization", parsedFields),
         super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// URI of the authorization server.

--- a/lib/src/definitions/security/combo_security_scheme.dart
+++ b/lib/src/definitions/security/combo_security_scheme.dart
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
-import 'security_scheme.dart';
+import "../extensions/json_parser.dart";
+import "security_scheme.dart";
 
-const _schemeName = 'combo';
+const _schemeName = "combo";
 
 /// A combination of other security schemes identified by the Vocabulary Term
 /// `combo` (i.e., "scheme": "combo").
@@ -30,8 +30,8 @@ final class ComboSecurityScheme extends SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : oneOf = json.parseArrayField<String>('oneOf', parsedFields),
-        allOf = json.parseArrayField<String>('allOf', parsedFields),
+  )   : oneOf = json.parseArrayField<String>("oneOf", parsedFields),
+        allOf = json.parseArrayField<String>("allOf", parsedFields),
         super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// Array of two or more strings identifying other named security scheme

--- a/lib/src/definitions/security/digest_security_scheme.dart
+++ b/lib/src/definitions/security/digest_security_scheme.dart
@@ -4,14 +4,14 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
-import 'security_scheme.dart';
+import "../extensions/json_parser.dart";
+import "security_scheme.dart";
 
-const _defaultInValue = 'header';
+const _defaultInValue = "header";
 
-const _defaultQoPValue = 'auth';
+const _defaultQoPValue = "auth";
 
 /// Digest Access Authentication security configuration identified by the
 /// Vocabulary Term `digest`.
@@ -26,17 +26,17 @@ final class DigestSecurityScheme extends SecurityScheme {
     super.proxy,
     super.jsonLdType,
     super.additionalFields,
-  }) : super('digest');
+  }) : super("digest");
 
   /// Creates a [DigestSecurityScheme] from a [json] object.
   DigestSecurityScheme.fromJson(
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : name = json.parseField<String>('name', parsedFields),
-        in_ = json.parseField<String>('in', parsedFields) ?? _defaultInValue,
-        qop = json.parseField<String>('qop', parsedFields) ?? _defaultInValue,
-        super.fromJson('digest', json, prefixMapping, parsedFields);
+  )   : name = json.parseField<String>("name", parsedFields),
+        in_ = json.parseField<String>("in", parsedFields) ?? _defaultInValue,
+        qop = json.parseField<String>("qop", parsedFields) ?? _defaultInValue,
+        super.fromJson("digest", json, prefixMapping, parsedFields);
 
   /// Name for query, header, cookie, or uri parameters.
   final String? name;

--- a/lib/src/definitions/security/no_security_scheme.dart
+++ b/lib/src/definitions/security/no_security_scheme.dart
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import 'security_scheme.dart';
+import "security_scheme.dart";
 
-const _schemeName = 'nosec';
+const _schemeName = "nosec";
 
 /// A security configuration corresponding to identified by the Vocabulary Term
 /// `nosec`.

--- a/lib/src/definitions/security/oauth2_security_scheme.dart
+++ b/lib/src/definitions/security/oauth2_security_scheme.dart
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
-import 'security_scheme.dart';
+import "../extensions/json_parser.dart";
+import "security_scheme.dart";
 
-const _schemeName = 'oauth2';
+const _schemeName = "oauth2";
 
 /// OAuth 2.0 authentication security configuration for systems conformant with
 /// RFC 6749, RFC 8252 and (for the device flow) RFC 8628, identified by the
@@ -34,11 +34,11 @@ final class OAuth2SecurityScheme extends SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : authorization = json.parseField<String>('authorization', parsedFields),
-        token = json.parseField<String>('token', parsedFields),
-        refresh = json.parseField<String>('refresh', parsedFields),
-        scopes = json.parseArrayField<String>('scopes', parsedFields),
-        flow = json.parseRequiredField<String>('flow', parsedFields),
+  )   : authorization = json.parseField<String>("authorization", parsedFields),
+        token = json.parseField<String>("token", parsedFields),
+        refresh = json.parseField<String>("refresh", parsedFields),
+        scopes = json.parseArrayField<String>("scopes", parsedFields),
+        flow = json.parseRequiredField<String>("flow", parsedFields),
         super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// URI of the authorization server.

--- a/lib/src/definitions/security/psk_security_scheme.dart
+++ b/lib/src/definitions/security/psk_security_scheme.dart
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
-import 'security_scheme.dart';
+import "../extensions/json_parser.dart";
+import "security_scheme.dart";
 
-const _schemeName = 'psk';
+const _schemeName = "psk";
 
 /// Pre-shared key authentication security configuration identified by the
 /// Vocabulary Term `psk`.
@@ -29,7 +29,7 @@ final class PskSecurityScheme extends SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : identity = json.parseField<String>('identity'),
+  )   : identity = json.parseField<String>("identity"),
         super.fromJson(_schemeName, json, prefixMapping, parsedFields);
 
   /// Name for query, header, cookie, or uri parameters.

--- a/lib/src/definitions/security/security_scheme.dart
+++ b/lib/src/definitions/security/security_scheme.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import '../extensions/json_parser.dart';
+import "../extensions/json_parser.dart";
 
 /// Class that contains metadata describing the configuration of a security
 /// mechanism.
@@ -27,10 +27,10 @@ base class SecurityScheme {
     Map<String, dynamic> json,
     PrefixMapping prefixMapping,
     Set<String> parsedFields,
-  )   : proxy = json.parseUriField('proxy', parsedFields),
-        description = json.parseField<String>('description', parsedFields),
-        descriptions = json.parseMapField<String>('descriptions', parsedFields),
-        jsonLdType = json.parseArrayField<String>('@type'),
+  )   : proxy = json.parseUriField("proxy", parsedFields),
+        description = json.parseField<String>("description", parsedFields),
+        descriptions = json.parseMapField<String>("descriptions", parsedFields),
+        jsonLdType = json.parseArrayField<String>("@type"),
         additionalFields =
             json.parseAdditionalFields(prefixMapping, parsedFields);
 

--- a/lib/src/definitions/thing_description.dart
+++ b/lib/src/definitions/thing_description.dart
@@ -4,22 +4,22 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
+import "dart:convert";
 
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import 'additional_expected_response.dart';
-import 'data_schema.dart';
-import 'extensions/json_parser.dart';
-import 'form.dart';
-import 'interaction_affordances/action.dart';
-import 'interaction_affordances/event.dart';
-import 'interaction_affordances/property.dart';
-import 'link.dart';
-import 'security/security_scheme.dart';
-import 'thing_model.dart';
-import 'validation/thing_description_schema.dart';
-import 'version_info.dart';
+import "additional_expected_response.dart";
+import "data_schema.dart";
+import "extensions/json_parser.dart";
+import "form.dart";
+import "interaction_affordances/action.dart";
+import "interaction_affordances/event.dart";
+import "interaction_affordances/property.dart";
+import "link.dart";
+import "security/security_scheme.dart";
+import "thing_model.dart";
+import "validation/thing_description_schema.dart";
+import "version_info.dart";
 
 /// Type definition for a JSON-LD @context entry.
 typedef ContextEntry = ({String? key, String value});
@@ -175,21 +175,21 @@ class ThingDescription {
     final Set<String> parsedFields = {};
 
     context.addAll(json.parseContext(prefixMapping, parsedFields));
-    atType = json.parseArrayField('@type', parsedFields);
-    title = json.parseRequiredField<String>('title', parsedFields);
-    titles.addAll(json.parseMapField<String>('titles', parsedFields) ?? {});
-    description = json.parseField<String>('description', parsedFields);
+    atType = json.parseArrayField("@type", parsedFields);
+    title = json.parseRequiredField<String>("title", parsedFields);
+    titles.addAll(json.parseMapField<String>("titles", parsedFields) ?? {});
+    description = json.parseField<String>("description", parsedFields);
     descriptions
-        .addAll(json.parseMapField<String>('descriptions', parsedFields) ?? {});
+        .addAll(json.parseMapField<String>("descriptions", parsedFields) ?? {});
     version = json.parseVersionInfo(prefixMapping, parsedFields);
-    created = json.parseDateTime('created', parsedFields);
-    modified = json.parseDateTime('modified', parsedFields);
-    support = json.parseUriField('support', parsedFields);
-    base = json.parseUriField('base', parsedFields);
-    id = json.parseField<String>('id', parsedFields);
+    created = json.parseDateTime("created", parsedFields);
+    modified = json.parseDateTime("modified", parsedFields);
+    support = json.parseUriField("support", parsedFields);
+    base = json.parseUriField("base", parsedFields);
+    id = json.parseField<String>("id", parsedFields);
 
     security
-        .addAll(json.parseArrayField<String>('security', parsedFields) ?? []);
+        .addAll(json.parseArrayField<String>("security", parsedFields) ?? []);
 
     securityDefinitions.addAll(
       json.parseSecurityDefinitions(prefixMapping, parsedFields) ?? {},
@@ -203,16 +203,16 @@ class ThingDescription {
 
     links.addAll(json.parseLinks(prefixMapping, parsedFields) ?? []);
 
-    profile.addAll(json.parseUriArrayField('profile', parsedFields) ?? []);
+    profile.addAll(json.parseUriArrayField("profile", parsedFields) ?? []);
     schemaDefinitions.addAll(
       json.parseDataSchemaMapField(
-            'schemaDefinitions',
+            "schemaDefinitions",
             prefixMapping,
             parsedFields,
           ) ??
           {},
     );
-    uriVariables = json.parseMapField<dynamic>('uriVariables', parsedFields);
+    uriVariables = json.parseMapField<dynamic>("uriVariables", parsedFields);
     additionalFields
         .addAll(json.parseAdditionalFields(prefixMapping, parsedFields));
   }

--- a/lib/src/definitions/thing_model.dart
+++ b/lib/src/definitions/thing_model.dart
@@ -4,7 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'thing_description.dart';
+import "thing_description.dart";
 
 /// Class representing a WoT Thing Model.
 ///

--- a/lib/src/definitions/validation/thing_description_schema.dart
+++ b/lib/src/definitions/validation/thing_description_schema.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:json_schema/json_schema.dart';
+import "package:json_schema/json_schema.dart";
 
-import 'validation_exception.dart';
+import "validation_exception.dart";
 
 /// JSON Schema definition used for validating Thing Descriptions.
 final thingDescriptionSchema = JsonSchema.create(_rawThingDescriptionSchema);
@@ -18,7 +18,7 @@ class ThingDescriptionValidationException extends ValidationException {
   ThingDescriptionValidationException(
     this.rawThingDescription,
     this._validationErrors,
-  ) : super('Validation of Thing Description failed');
+  ) : super("Validation of Thing Description failed");
 
   final List<ValidationError> _validationErrors;
 
@@ -27,920 +27,920 @@ class ThingDescriptionValidationException extends ValidationException {
 
   @override
   String toString() {
-    return 'ThingDescriptionValidationException: $message.\n\n'
+    return "ThingDescriptionValidationException: $message.\n\n"
         'Errors:\n\n ${_validationErrors.join("\n")}';
   }
 }
 
 final Map<String, dynamic> _rawThingDescriptionSchema = <String, dynamic>{
-  'title': 'Thing Description',
-  'version': '1.1-09-November-2023',
-  'description':
-      'JSON Schema for validating TD instances against the TD information '
-          'model. TD instances can be with or without terms that have default '
-          'values',
-  '\$schema': 'http://json-schema.org/draft-07/schema#',
-  '\$id':
-      'https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json',
-  'definitions': {
-    'anyUri': {'type': 'string'},
-    'description': {'type': 'string'},
-    'descriptions': {
-      'type': 'object',
-      'additionalProperties': {'type': 'string'},
+  "title": "Thing Description",
+  "version": "1.1-09-November-2023",
+  "description":
+      "JSON Schema for validating TD instances against the TD information "
+          "model. TD instances can be with or without terms that have default "
+          "values",
+  "\$schema": "http://json-schema.org/draft-07/schema#",
+  "\$id":
+      "https://raw.githubusercontent.com/w3c/wot-thing-description/main/validation/td-json-schema-validation.json",
+  "definitions": {
+    "anyUri": {"type": "string"},
+    "description": {"type": "string"},
+    "descriptions": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
     },
-    'title': {'type': 'string'},
-    'titles': {
-      'type': 'object',
-      'additionalProperties': {'type': 'string'},
+    "title": {"type": "string"},
+    "titles": {
+      "type": "object",
+      "additionalProperties": {"type": "string"},
     },
-    'security': {
-      'oneOf': [
+    "security": {
+      "oneOf": [
         {
-          'type': 'array',
-          'items': {'type': 'string'},
-          'minItems': 1,
+          "type": "array",
+          "items": {"type": "string"},
+          "minItems": 1,
         },
-        {'type': 'string'},
+        {"type": "string"},
       ],
     },
-    'scopes': {
-      'oneOf': [
+    "scopes": {
+      "oneOf": [
         {
-          'type': 'array',
-          'items': {'type': 'string'},
+          "type": "array",
+          "items": {"type": "string"},
         },
-        {'type': 'string'},
+        {"type": "string"},
       ],
     },
-    'subprotocol': {
-      'type': 'string',
-      'examples': ['longpoll', 'websub', 'sse'],
+    "subprotocol": {
+      "type": "string",
+      "examples": ["longpoll", "websub", "sse"],
     },
-    'thing-context-td-uri-v1': {
-      'type': 'string',
-      'const': 'https://www.w3.org/2019/wot/td/v1',
+    "thing-context-td-uri-v1": {
+      "type": "string",
+      "const": "https://www.w3.org/2019/wot/td/v1",
     },
-    'thing-context-td-uri-v1.1': {
-      'type': 'string',
-      'const': 'https://www.w3.org/2022/wot/td/v1.1',
+    "thing-context-td-uri-v1.1": {
+      "type": "string",
+      "const": "https://www.w3.org/2022/wot/td/v1.1",
     },
-    'thing-context-td-uri-temp': {
-      'type': 'string',
-      'const': 'http://www.w3.org/ns/td',
+    "thing-context-td-uri-temp": {
+      "type": "string",
+      "const": "http://www.w3.org/ns/td",
     },
-    'thing-context': {
-      'anyOf': [
+    "thing-context": {
+      "anyOf": [
         {
-          '\$comment':
-              'New context URI with other vocabularies after it but not the '
-                  'old one',
-          'type': 'array',
-          'items': [
-            {'\$ref': '#/definitions/thing-context-td-uri-v1.1'},
+          "\$comment":
+              "New context URI with other vocabularies after it but not the "
+                  "old one",
+          "type": "array",
+          "items": [
+            {"\$ref": "#/definitions/thing-context-td-uri-v1.1"},
           ],
-          'additionalItems': {
-            'anyOf': [
-              {'\$ref': '#/definitions/anyUri'},
-              {'type': 'object'},
+          "additionalItems": {
+            "anyOf": [
+              {"\$ref": "#/definitions/anyUri"},
+              {"type": "object"},
             ],
-            'not': {'\$ref': '#/definitions/thing-context-td-uri-v1'},
+            "not": {"\$ref": "#/definitions/thing-context-td-uri-v1"},
           },
         },
         {
-          '\$comment': 'Only the new context URI',
-          '\$ref': '#/definitions/thing-context-td-uri-v1.1',
+          "\$comment": "Only the new context URI",
+          "\$ref": "#/definitions/thing-context-td-uri-v1.1",
         },
         {
-          '\$comment':
-              'Old context URI, followed by the new one and possibly other '
-                  'vocabularies. minItems and contains are required since '
-                  'prefixItems does not say all items should be provided',
-          'type': 'array',
-          'prefixItems': [
-            {'\$ref': '#/definitions/thing-context-td-uri-v1'},
-            {'\$ref': '#/definitions/thing-context-td-uri-v1.1'},
+          "\$comment":
+              "Old context URI, followed by the new one and possibly other "
+                  "vocabularies. minItems and contains are required since "
+                  "prefixItems does not say all items should be provided",
+          "type": "array",
+          "prefixItems": [
+            {"\$ref": "#/definitions/thing-context-td-uri-v1"},
+            {"\$ref": "#/definitions/thing-context-td-uri-v1.1"},
           ],
-          'minItems': 2,
-          'contains': {'\$ref': '#/definitions/thing-context-td-uri-v1.1'},
-          'additionalItems': {
-            'anyOf': [
-              {'\$ref': '#/definitions/anyUri'},
-              {'type': 'object'},
-            ],
-          },
-        },
-        {
-          '\$comment':
-              'Old context URI, followed by possibly other vocabularies. '
-                  'minItems and contains are required since prefixItems does '
-                  'not say all items should be provided',
-          'type': 'array',
-          'prefixItems': [
-            {'\$ref': '#/definitions/thing-context-td-uri-v1'},
-          ],
-          'minItems': 1,
-          'contains': {'\$ref': '#/definitions/thing-context-td-uri-v1'},
-          'additionalItems': {
-            'anyOf': [
-              {'\$ref': '#/definitions/anyUri'},
-              {'type': 'object'},
+          "minItems": 2,
+          "contains": {"\$ref": "#/definitions/thing-context-td-uri-v1.1"},
+          "additionalItems": {
+            "anyOf": [
+              {"\$ref": "#/definitions/anyUri"},
+              {"type": "object"},
             ],
           },
         },
         {
-          '\$comment': 'Only the old context URI',
-          '\$ref': '#/definitions/thing-context-td-uri-v1',
+          "\$comment":
+              "Old context URI, followed by possibly other vocabularies. "
+                  "minItems and contains are required since prefixItems does "
+                  "not say all items should be provided",
+          "type": "array",
+          "prefixItems": [
+            {"\$ref": "#/definitions/thing-context-td-uri-v1"},
+          ],
+          "minItems": 1,
+          "contains": {"\$ref": "#/definitions/thing-context-td-uri-v1"},
+          "additionalItems": {
+            "anyOf": [
+              {"\$ref": "#/definitions/anyUri"},
+              {"type": "object"},
+            ],
+          },
+        },
+        {
+          "\$comment": "Only the old context URI",
+          "\$ref": "#/definitions/thing-context-td-uri-v1",
         }
       ],
     },
-    'bcp47_string': {
-      'type': 'string',
-      'pattern':
-          '^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|'
-              '[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?'
-              '(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z]'
-              '(-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|'
-              '(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|'
-              'i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|'
-              'i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|'
-              'cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|'
-              'zh-xiang)))\$',
+    "bcp47_string": {
+      "type": "string",
+      "pattern":
+          "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|"
+              "[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?"
+              "(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z]"
+              "(-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|"
+              "(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|"
+              "i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|"
+              "i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|"
+              "cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|"
+              "zh-xiang)))\$",
     },
-    'type_declaration': {
-      'oneOf': [
+    "type_declaration": {
+      "oneOf": [
         {
-          'type': 'string',
-          'not': {'const': 'tm:ThingModel'},
+          "type": "string",
+          "not": {"const": "tm:ThingModel"},
         },
         {
-          'type': 'array',
-          'items': {
-            'type': 'string',
-            'not': {'const': 'tm:ThingModel'},
+          "type": "array",
+          "items": {
+            "type": "string",
+            "not": {"const": "tm:ThingModel"},
           },
         }
       ],
     },
-    'dataSchema-type': {
-      'type': 'string',
-      'enum': [
-        'boolean',
-        'integer',
-        'number',
-        'string',
-        'object',
-        'array',
-        'null',
+    "dataSchema-type": {
+      "type": "string",
+      "enum": [
+        "boolean",
+        "integer",
+        "number",
+        "string",
+        "object",
+        "array",
+        "null",
       ],
     },
-    'dataSchema': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'title': {'\$ref': '#/definitions/title'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'titles': {'\$ref': '#/definitions/titles'},
-        'writeOnly': {'type': 'boolean'},
-        'readOnly': {'type': 'boolean'},
-        'oneOf': {
-          'type': 'array',
-          'items': {'\$ref': '#/definitions/dataSchema'},
+    "dataSchema": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "title": {"\$ref": "#/definitions/title"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "titles": {"\$ref": "#/definitions/titles"},
+        "writeOnly": {"type": "boolean"},
+        "readOnly": {"type": "boolean"},
+        "oneOf": {
+          "type": "array",
+          "items": {"\$ref": "#/definitions/dataSchema"},
         },
-        'unit': {'type': 'string'},
-        'enum': {'type': 'array', 'minItems': 1, 'uniqueItems': true},
-        'format': {'type': 'string'},
-        'const': {},
-        'default': {},
-        'contentEncoding': {'type': 'string'},
-        'contentMediaType': {'type': 'string'},
-        'type': {'\$ref': '#/definitions/dataSchema-type'},
-        'items': {
-          'oneOf': [
-            {'\$ref': '#/definitions/dataSchema'},
+        "unit": {"type": "string"},
+        "enum": {"type": "array", "minItems": 1, "uniqueItems": true},
+        "format": {"type": "string"},
+        "const": {},
+        "default": {},
+        "contentEncoding": {"type": "string"},
+        "contentMediaType": {"type": "string"},
+        "type": {"\$ref": "#/definitions/dataSchema-type"},
+        "items": {
+          "oneOf": [
+            {"\$ref": "#/definitions/dataSchema"},
             {
-              'type': 'array',
-              'items': {'\$ref': '#/definitions/dataSchema'},
+              "type": "array",
+              "items": {"\$ref": "#/definitions/dataSchema"},
             }
           ],
         },
-        'maxItems': {'type': 'integer', 'minimum': 0},
-        'minItems': {'type': 'integer', 'minimum': 0},
-        'minimum': {'type': 'number'},
-        'maximum': {'type': 'number'},
-        'exclusiveMinimum': {'type': 'number'},
-        'exclusiveMaximum': {'type': 'number'},
-        'minLength': {'type': 'integer', 'minimum': 0},
-        'maxLength': {'type': 'integer', 'minimum': 0},
-        'multipleOf': {'\$ref': '#/definitions/multipleOfDefinition'},
-        'properties': {
-          'additionalProperties': {'\$ref': '#/definitions/dataSchema'},
+        "maxItems": {"type": "integer", "minimum": 0},
+        "minItems": {"type": "integer", "minimum": 0},
+        "minimum": {"type": "number"},
+        "maximum": {"type": "number"},
+        "exclusiveMinimum": {"type": "number"},
+        "exclusiveMaximum": {"type": "number"},
+        "minLength": {"type": "integer", "minimum": 0},
+        "maxLength": {"type": "integer", "minimum": 0},
+        "multipleOf": {"\$ref": "#/definitions/multipleOfDefinition"},
+        "properties": {
+          "additionalProperties": {"\$ref": "#/definitions/dataSchema"},
         },
-        'required': {
-          'type': 'array',
-          'items': {'type': 'string'},
-        },
-      },
-    },
-    'additionalResponsesDefinition': {
-      'type': 'array',
-      'items': {
-        'type': 'object',
-        'properties': {
-          'contentType': {'type': 'string'},
-          'schema': {'type': 'string'},
-          'success': {'type': 'boolean'},
+        "required": {
+          "type": "array",
+          "items": {"type": "string"},
         },
       },
     },
-    'multipleOfDefinition': {
-      'type': ['integer', 'number'],
-      'exclusiveMinimum': 0,
-    },
-    'expectedResponse': {
-      'type': 'object',
-      'properties': {
-        'contentType': {'type': 'string'},
+    "additionalResponsesDefinition": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "contentType": {"type": "string"},
+          "schema": {"type": "string"},
+          "success": {"type": "boolean"},
+        },
       },
-      'required': ['contentType'],
     },
-    'form_element_base': {
-      'type': 'object',
-      'properties': {
-        'op': {
-          'oneOf': [
-            {'type': 'string'},
+    "multipleOfDefinition": {
+      "type": ["integer", "number"],
+      "exclusiveMinimum": 0,
+    },
+    "expectedResponse": {
+      "type": "object",
+      "properties": {
+        "contentType": {"type": "string"},
+      },
+      "required": ["contentType"],
+    },
+    "form_element_base": {
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
+            {"type": "string"},
             {
-              'type': 'array',
-              'items': {'type': 'string'},
+              "type": "array",
+              "items": {"type": "string"},
             }
           ],
         },
-        'href': {'\$ref': '#/definitions/anyUri'},
-        'contentType': {'type': 'string'},
-        'contentCoding': {'type': 'string'},
-        'subprotocol': {'\$ref': '#/definitions/subprotocol'},
-        'security': {'\$ref': '#/definitions/security'},
-        'scopes': {'\$ref': '#/definitions/scopes'},
-        'response': {'\$ref': '#/definitions/expectedResponse'},
-        'additionalResponses': {
-          '\$ref': '#/definitions/additionalResponsesDefinition',
+        "href": {"\$ref": "#/definitions/anyUri"},
+        "contentType": {"type": "string"},
+        "contentCoding": {"type": "string"},
+        "subprotocol": {"\$ref": "#/definitions/subprotocol"},
+        "security": {"\$ref": "#/definitions/security"},
+        "scopes": {"\$ref": "#/definitions/scopes"},
+        "response": {"\$ref": "#/definitions/expectedResponse"},
+        "additionalResponses": {
+          "\$ref": "#/definitions/additionalResponsesDefinition",
         },
       },
-      'required': ['href'],
-      'additionalProperties': true,
+      "required": ["href"],
+      "additionalProperties": true,
     },
-    'form_element_property': {
-      'allOf': [
-        {'\$ref': '#/definitions/form_element_base'},
+    "form_element_property": {
+      "allOf": [
+        {"\$ref": "#/definitions/form_element_base"},
       ],
-      'type': 'object',
-      'properties': {
-        'op': {
-          'oneOf': [
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
             {
-              'type': 'string',
-              'enum': [
-                'readproperty',
-                'writeproperty',
-                'observeproperty',
-                'unobserveproperty',
+              "type": "string",
+              "enum": [
+                "readproperty",
+                "writeproperty",
+                "observeproperty",
+                "unobserveproperty",
               ],
             },
             {
-              'type': 'array',
-              'items': {
-                'type': 'string',
-                'enum': [
-                  'readproperty',
-                  'writeproperty',
-                  'observeproperty',
-                  'unobserveproperty',
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "readproperty",
+                  "writeproperty",
+                  "observeproperty",
+                  "unobserveproperty",
                 ],
               },
-              'minItems': 1,
+              "minItems": 1,
             }
           ],
         },
       },
-      'additionalProperties': true,
+      "additionalProperties": true,
     },
-    'form_element_action': {
-      'allOf': [
-        {'\$ref': '#/definitions/form_element_base'},
+    "form_element_action": {
+      "allOf": [
+        {"\$ref": "#/definitions/form_element_base"},
       ],
-      'type': 'object',
-      'properties': {
-        'op': {
-          'oneOf': [
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
             {
-              'type': 'string',
-              'enum': ['invokeaction', 'queryaction', 'cancelaction'],
+              "type": "string",
+              "enum": ["invokeaction", "queryaction", "cancelaction"],
             },
             {
-              'type': 'array',
-              'items': {
-                'type': 'string',
-                'enum': ['invokeaction', 'queryaction', 'cancelaction'],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["invokeaction", "queryaction", "cancelaction"],
               },
-              'minItems': 1,
+              "minItems": 1,
             }
           ],
         },
       },
-      'additionalProperties': true,
+      "additionalProperties": true,
     },
-    'form_element_event': {
-      'allOf': [
-        {'\$ref': '#/definitions/form_element_base'},
+    "form_element_event": {
+      "allOf": [
+        {"\$ref": "#/definitions/form_element_base"},
       ],
-      'type': 'object',
-      'properties': {
-        'op': {
-          'oneOf': [
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
             {
-              'type': 'string',
-              'enum': ['subscribeevent', 'unsubscribeevent'],
+              "type": "string",
+              "enum": ["subscribeevent", "unsubscribeevent"],
             },
             {
-              'type': 'array',
-              'items': {
-                'type': 'string',
-                'enum': ['subscribeevent', 'unsubscribeevent'],
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": ["subscribeevent", "unsubscribeevent"],
               },
-              'minItems': 1,
+              "minItems": 1,
             }
           ],
         },
       },
-      'additionalProperties': true,
+      "additionalProperties": true,
     },
-    'form_element_root': {
-      'allOf': [
-        {'\$ref': '#/definitions/form_element_base'},
+    "form_element_root": {
+      "allOf": [
+        {"\$ref": "#/definitions/form_element_base"},
       ],
-      'type': 'object',
-      'properties': {
-        'op': {
-          'oneOf': [
+      "type": "object",
+      "properties": {
+        "op": {
+          "oneOf": [
             {
-              'type': 'string',
-              'enum': [
-                'readallproperties',
-                'writeallproperties',
-                'readmultipleproperties',
-                'writemultipleproperties',
-                'observeallproperties',
-                'unobserveallproperties',
-                'queryallactions',
-                'subscribeallevents',
-                'unsubscribeallevents',
+              "type": "string",
+              "enum": [
+                "readallproperties",
+                "writeallproperties",
+                "readmultipleproperties",
+                "writemultipleproperties",
+                "observeallproperties",
+                "unobserveallproperties",
+                "queryallactions",
+                "subscribeallevents",
+                "unsubscribeallevents",
               ],
             },
             {
-              'type': 'array',
-              'items': {
-                'type': 'string',
-                'enum': [
-                  'readallproperties',
-                  'writeallproperties',
-                  'readmultipleproperties',
-                  'writemultipleproperties',
-                  'observeallproperties',
-                  'unobserveallproperties',
-                  'queryallactions',
-                  'subscribeallevents',
-                  'unsubscribeallevents',
+              "type": "array",
+              "items": {
+                "type": "string",
+                "enum": [
+                  "readallproperties",
+                  "writeallproperties",
+                  "readmultipleproperties",
+                  "writemultipleproperties",
+                  "observeallproperties",
+                  "unobserveallproperties",
+                  "queryallactions",
+                  "subscribeallevents",
+                  "unsubscribeallevents",
                 ],
               },
-              'minItems': 1,
+              "minItems": 1,
             }
           ],
         },
       },
-      'additionalProperties': true,
-      'required': ['op'],
+      "additionalProperties": true,
+      "required": ["op"],
     },
-    'form': {
-      '\$comment':
-          'This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057',
-      'oneOf': [
-        {'\$ref': '#/definitions/form_element_property'},
-        {'\$ref': '#/definitions/form_element_action'},
-        {'\$ref': '#/definitions/form_element_event'},
-        {'\$ref': '#/definitions/form_element_root'},
+    "form": {
+      "\$comment":
+          "This is NOT for validation purposes but for automatic generation of TS types. For more info, please see: https://github.com/w3c/wot-thing-description/pull/1319#issuecomment-994950057",
+      "oneOf": [
+        {"\$ref": "#/definitions/form_element_property"},
+        {"\$ref": "#/definitions/form_element_action"},
+        {"\$ref": "#/definitions/form_element_event"},
+        {"\$ref": "#/definitions/form_element_root"},
       ],
     },
-    'property_element': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'title': {'\$ref': '#/definitions/title'},
-        'titles': {'\$ref': '#/definitions/titles'},
-        'forms': {
-          'type': 'array',
-          'minItems': 1,
-          'items': {'\$ref': '#/definitions/form_element_property'},
+    "property_element": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "title": {"\$ref": "#/definitions/title"},
+        "titles": {"\$ref": "#/definitions/titles"},
+        "forms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"\$ref": "#/definitions/form_element_property"},
         },
-        'uriVariables': {
-          'type': 'object',
-          'additionalProperties': {'\$ref': '#/definitions/dataSchema'},
+        "uriVariables": {
+          "type": "object",
+          "additionalProperties": {"\$ref": "#/definitions/dataSchema"},
         },
-        'observable': {'type': 'boolean'},
-        'writeOnly': {'type': 'boolean'},
-        'readOnly': {'type': 'boolean'},
-        'oneOf': {
-          'type': 'array',
-          'items': {'\$ref': '#/definitions/dataSchema'},
+        "observable": {"type": "boolean"},
+        "writeOnly": {"type": "boolean"},
+        "readOnly": {"type": "boolean"},
+        "oneOf": {
+          "type": "array",
+          "items": {"\$ref": "#/definitions/dataSchema"},
         },
-        'unit': {'type': 'string'},
-        'enum': {'type': 'array', 'minItems': 1, 'uniqueItems': true},
-        'format': {'type': 'string'},
-        'const': {},
-        'default': {},
-        'type': {'\$ref': '#/definitions/dataSchema-type'},
-        'items': {
-          'oneOf': [
-            {'\$ref': '#/definitions/dataSchema'},
+        "unit": {"type": "string"},
+        "enum": {"type": "array", "minItems": 1, "uniqueItems": true},
+        "format": {"type": "string"},
+        "const": {},
+        "default": {},
+        "type": {"\$ref": "#/definitions/dataSchema-type"},
+        "items": {
+          "oneOf": [
+            {"\$ref": "#/definitions/dataSchema"},
             {
-              'type': 'array',
-              'items': {'\$ref': '#/definitions/dataSchema'},
+              "type": "array",
+              "items": {"\$ref": "#/definitions/dataSchema"},
             }
           ],
         },
-        'maxItems': {'type': 'integer', 'minimum': 0},
-        'minItems': {'type': 'integer', 'minimum': 0},
-        'minimum': {'type': 'number'},
-        'maximum': {'type': 'number'},
-        'exclusiveMinimum': {'type': 'number'},
-        'exclusiveMaximum': {'type': 'number'},
-        'minLength': {'type': 'integer', 'minimum': 0},
-        'maxLength': {'type': 'integer', 'minimum': 0},
-        'multipleOf': {'\$ref': '#/definitions/multipleOfDefinition'},
-        'properties': {
-          'additionalProperties': {'\$ref': '#/definitions/dataSchema'},
+        "maxItems": {"type": "integer", "minimum": 0},
+        "minItems": {"type": "integer", "minimum": 0},
+        "minimum": {"type": "number"},
+        "maximum": {"type": "number"},
+        "exclusiveMinimum": {"type": "number"},
+        "exclusiveMaximum": {"type": "number"},
+        "minLength": {"type": "integer", "minimum": 0},
+        "maxLength": {"type": "integer", "minimum": 0},
+        "multipleOf": {"\$ref": "#/definitions/multipleOfDefinition"},
+        "properties": {
+          "additionalProperties": {"\$ref": "#/definitions/dataSchema"},
         },
-        'required': {
-          'type': 'array',
-          'items': {'type': 'string'},
+        "required": {
+          "type": "array",
+          "items": {"type": "string"},
         },
       },
-      'required': ['forms'],
-      'additionalProperties': true,
+      "required": ["forms"],
+      "additionalProperties": true,
     },
-    'action_element': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'title': {'\$ref': '#/definitions/title'},
-        'titles': {'\$ref': '#/definitions/titles'},
-        'forms': {
-          'type': 'array',
-          'minItems': 1,
-          'items': {'\$ref': '#/definitions/form_element_action'},
+    "action_element": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "title": {"\$ref": "#/definitions/title"},
+        "titles": {"\$ref": "#/definitions/titles"},
+        "forms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"\$ref": "#/definitions/form_element_action"},
         },
-        'uriVariables': {
-          'type': 'object',
-          'additionalProperties': {'\$ref': '#/definitions/dataSchema'},
+        "uriVariables": {
+          "type": "object",
+          "additionalProperties": {"\$ref": "#/definitions/dataSchema"},
         },
-        'input': {'\$ref': '#/definitions/dataSchema'},
-        'output': {'\$ref': '#/definitions/dataSchema'},
-        'safe': {'type': 'boolean'},
-        'idempotent': {'type': 'boolean'},
-        'synchronous': {'type': 'boolean'},
+        "input": {"\$ref": "#/definitions/dataSchema"},
+        "output": {"\$ref": "#/definitions/dataSchema"},
+        "safe": {"type": "boolean"},
+        "idempotent": {"type": "boolean"},
+        "synchronous": {"type": "boolean"},
       },
-      'required': ['forms'],
-      'additionalProperties': true,
+      "required": ["forms"],
+      "additionalProperties": true,
     },
-    'event_element': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'title': {'\$ref': '#/definitions/title'},
-        'titles': {'\$ref': '#/definitions/titles'},
-        'forms': {
-          'type': 'array',
-          'minItems': 1,
-          'items': {'\$ref': '#/definitions/form_element_event'},
+    "event_element": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "title": {"\$ref": "#/definitions/title"},
+        "titles": {"\$ref": "#/definitions/titles"},
+        "forms": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"\$ref": "#/definitions/form_element_event"},
         },
-        'uriVariables': {
-          'type': 'object',
-          'additionalProperties': {'\$ref': '#/definitions/dataSchema'},
+        "uriVariables": {
+          "type": "object",
+          "additionalProperties": {"\$ref": "#/definitions/dataSchema"},
         },
-        'subscription': {'\$ref': '#/definitions/dataSchema'},
-        'data': {'\$ref': '#/definitions/dataSchema'},
-        'dataResponse': {'\$ref': '#/definitions/dataSchema'},
-        'cancellation': {'\$ref': '#/definitions/dataSchema'},
+        "subscription": {"\$ref": "#/definitions/dataSchema"},
+        "data": {"\$ref": "#/definitions/dataSchema"},
+        "dataResponse": {"\$ref": "#/definitions/dataSchema"},
+        "cancellation": {"\$ref": "#/definitions/dataSchema"},
       },
-      'required': ['forms'],
-      'additionalProperties': true,
+      "required": ["forms"],
+      "additionalProperties": true,
     },
-    'base_link_element': {
-      'type': 'object',
-      'properties': {
-        'href': {'\$ref': '#/definitions/anyUri'},
-        'type': {'type': 'string'},
-        'rel': {'type': 'string'},
-        'anchor': {'\$ref': '#/definitions/anyUri'},
-        'hreflang': {
-          'anyOf': [
-            {'\$ref': '#/definitions/bcp47_string'},
+    "base_link_element": {
+      "type": "object",
+      "properties": {
+        "href": {"\$ref": "#/definitions/anyUri"},
+        "type": {"type": "string"},
+        "rel": {"type": "string"},
+        "anchor": {"\$ref": "#/definitions/anyUri"},
+        "hreflang": {
+          "anyOf": [
+            {"\$ref": "#/definitions/bcp47_string"},
             {
-              'type': 'array',
-              'items': {'\$ref': '#/definitions/bcp47_string'},
+              "type": "array",
+              "items": {"\$ref": "#/definitions/bcp47_string"},
             }
           ],
         },
       },
-      'required': ['href'],
-      'additionalProperties': true,
+      "required": ["href"],
+      "additionalProperties": true,
     },
-    'link_element': {
-      'allOf': [
-        {'\$ref': '#/definitions/base_link_element'},
+    "link_element": {
+      "allOf": [
+        {"\$ref": "#/definitions/base_link_element"},
         {
-          'not': {
-            'description': 'A basic link element should not contain sizes',
-            'type': 'object',
-            'properties': {'sizes': {}},
-            'required': ['sizes'],
+          "not": {
+            "description": "A basic link element should not contain sizes",
+            "type": "object",
+            "properties": {"sizes": {}},
+            "required": ["sizes"],
           },
         },
         {
-          'not': {
-            'description':
-                'A basic link element should not contain icon or tm:extends',
-            'properties': {
-              'rel': {
-                'enum': ['icon', 'tm:extends'],
+          "not": {
+            "description":
+                "A basic link element should not contain icon or tm:extends",
+            "properties": {
+              "rel": {
+                "enum": ["icon", "tm:extends"],
               },
             },
-            'required': ['rel'],
+            "required": ["rel"],
           },
         }
       ],
     },
-    'icon_link_element': {
-      'allOf': [
-        {'\$ref': '#/definitions/base_link_element'},
+    "icon_link_element": {
+      "allOf": [
+        {"\$ref": "#/definitions/base_link_element"},
         {
-          'properties': {
-            'rel': {'const': 'icon'},
-            'sizes': {'type': 'string', 'pattern': '[0-9]*x[0-9]+'},
+          "properties": {
+            "rel": {"const": "icon"},
+            "sizes": {"type": "string", "pattern": "[0-9]*x[0-9]+"},
           },
-          'required': ['rel'],
+          "required": ["rel"],
         }
       ],
     },
-    'additionalSecurityScheme': {
-      'description':
-          'Applies to additional SecuritySchemes not defined in the WoT TD '
-              'specification.',
-      '\$comment':
-          'Additional SecuritySchemes should always be defined via a context '
-              'extension, using a prefixed value for the scheme. This prefix '
+    "additionalSecurityScheme": {
+      "description":
+          "Applies to additional SecuritySchemes not defined in the WoT TD "
+              "specification.",
+      "\$comment":
+          "Additional SecuritySchemes should always be defined via a context "
+              "extension, using a prefixed value for the scheme. This prefix "
               "(e.g. 'ace', see the example below) must contain at least one "
-              'character in order to reference a valid JSON-LD context '
-              'extension.',
-      'examples': [
+              "character in order to reference a valid JSON-LD context "
+              "extension.",
+      "examples": [
         {
-          'scheme': 'ace:ACESecurityScheme',
-          'ace:as': 'coaps://as.example.com/token',
-          'ace:audience': 'coaps://rs.example.com',
-          'ace:scopes': ['limited', 'special'],
-          'ace:cnonce': true,
+          "scheme": "ace:ACESecurityScheme",
+          "ace:as": "coaps://as.example.com/token",
+          "ace:audience": "coaps://rs.example.com",
+          "ace:scopes": ["limited", "special"],
+          "ace:cnonce": true,
         }
       ],
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {'type': 'string', 'pattern': '.+:.*'},
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {"type": "string", "pattern": ".+:.*"},
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'noSecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['nosec'],
+    "noSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["nosec"],
         },
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'autoSecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['auto'],
+    "autoSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["auto"],
         },
       },
-      'not': {
-        'required': ['name'],
+      "not": {
+        "required": ["name"],
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'comboSecurityScheme': {
-      'oneOf': [
+    "comboSecurityScheme": {
+      "oneOf": [
         {
-          'type': 'object',
-          'properties': {
-            '@type': {'\$ref': '#/definitions/type_declaration'},
-            'description': {'\$ref': '#/definitions/description'},
-            'descriptions': {'\$ref': '#/definitions/descriptions'},
-            'proxy': {'\$ref': '#/definitions/anyUri'},
-            'scheme': {
-              'type': 'string',
-              'enum': ['combo'],
+          "type": "object",
+          "properties": {
+            "@type": {"\$ref": "#/definitions/type_declaration"},
+            "description": {"\$ref": "#/definitions/description"},
+            "descriptions": {"\$ref": "#/definitions/descriptions"},
+            "proxy": {"\$ref": "#/definitions/anyUri"},
+            "scheme": {
+              "type": "string",
+              "enum": ["combo"],
             },
-            'oneOf': {
-              'type': 'array',
-              'minItems': 2,
-              'items': {'type': 'string'},
+            "oneOf": {
+              "type": "array",
+              "minItems": 2,
+              "items": {"type": "string"},
             },
           },
-          'required': ['scheme', 'oneOf'],
-          'additionalProperties': true,
+          "required": ["scheme", "oneOf"],
+          "additionalProperties": true,
         },
         {
-          'type': 'object',
-          'properties': {
-            '@type': {'\$ref': '#/definitions/type_declaration'},
-            'description': {'\$ref': '#/definitions/description'},
-            'descriptions': {'\$ref': '#/definitions/descriptions'},
-            'proxy': {'\$ref': '#/definitions/anyUri'},
-            'scheme': {
-              'type': 'string',
-              'enum': ['combo'],
+          "type": "object",
+          "properties": {
+            "@type": {"\$ref": "#/definitions/type_declaration"},
+            "description": {"\$ref": "#/definitions/description"},
+            "descriptions": {"\$ref": "#/definitions/descriptions"},
+            "proxy": {"\$ref": "#/definitions/anyUri"},
+            "scheme": {
+              "type": "string",
+              "enum": ["combo"],
             },
-            'allOf': {
-              'type': 'array',
-              'minItems': 2,
-              'items': {'type': 'string'},
+            "allOf": {
+              "type": "array",
+              "minItems": 2,
+              "items": {"type": "string"},
             },
           },
-          'required': ['scheme', 'allOf'],
-          'additionalProperties': true,
+          "required": ["scheme", "allOf"],
+          "additionalProperties": true,
         }
       ],
     },
-    'basicSecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['basic'],
+    "basicSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["basic"],
         },
-        'in': {
-          'type': 'string',
-          'enum': ['header', 'query', 'body', 'cookie', 'auto'],
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "auto"],
         },
-        'name': {'type': 'string'},
+        "name": {"type": "string"},
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'digestSecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['digest'],
+    "digestSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["digest"],
         },
-        'qop': {
-          'type': 'string',
-          'enum': ['auth', 'auth-int'],
+        "qop": {
+          "type": "string",
+          "enum": ["auth", "auth-int"],
         },
-        'in': {
-          'type': 'string',
-          'enum': ['header', 'query', 'body', 'cookie', 'auto'],
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "auto"],
         },
-        'name': {'type': 'string'},
+        "name": {"type": "string"},
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'apiKeySecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['apikey'],
+    "apiKeySecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["apikey"],
         },
-        'in': {
-          'type': 'string',
-          'enum': ['header', 'query', 'body', 'cookie', 'uri', 'auto'],
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "uri", "auto"],
         },
-        'name': {'type': 'string'},
+        "name": {"type": "string"},
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'bearerSecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['bearer'],
+    "bearerSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["bearer"],
         },
-        'authorization': {'\$ref': '#/definitions/anyUri'},
-        'alg': {'type': 'string'},
-        'format': {'type': 'string'},
-        'in': {
-          'type': 'string',
-          'enum': ['header', 'query', 'body', 'cookie', 'auto'],
+        "authorization": {"\$ref": "#/definitions/anyUri"},
+        "alg": {"type": "string"},
+        "format": {"type": "string"},
+        "in": {
+          "type": "string",
+          "enum": ["header", "query", "body", "cookie", "auto"],
         },
-        'name': {'type': 'string'},
+        "name": {"type": "string"},
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'pskSecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['psk'],
+    "pskSecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["psk"],
         },
-        'identity': {'type': 'string'},
+        "identity": {"type": "string"},
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'oAuth2SecurityScheme': {
-      'type': 'object',
-      'properties': {
-        '@type': {'\$ref': '#/definitions/type_declaration'},
-        'description': {'\$ref': '#/definitions/description'},
-        'descriptions': {'\$ref': '#/definitions/descriptions'},
-        'proxy': {'\$ref': '#/definitions/anyUri'},
-        'scheme': {
-          'type': 'string',
-          'enum': ['oauth2'],
+    "oAuth2SecurityScheme": {
+      "type": "object",
+      "properties": {
+        "@type": {"\$ref": "#/definitions/type_declaration"},
+        "description": {"\$ref": "#/definitions/description"},
+        "descriptions": {"\$ref": "#/definitions/descriptions"},
+        "proxy": {"\$ref": "#/definitions/anyUri"},
+        "scheme": {
+          "type": "string",
+          "enum": ["oauth2"],
         },
-        'authorization': {'\$ref': '#/definitions/anyUri'},
-        'token': {'\$ref': '#/definitions/anyUri'},
-        'refresh': {'\$ref': '#/definitions/anyUri'},
-        'scopes': {
-          'oneOf': [
+        "authorization": {"\$ref": "#/definitions/anyUri"},
+        "token": {"\$ref": "#/definitions/anyUri"},
+        "refresh": {"\$ref": "#/definitions/anyUri"},
+        "scopes": {
+          "oneOf": [
             {
-              'type': 'array',
-              'items': {'type': 'string'},
+              "type": "array",
+              "items": {"type": "string"},
             },
-            {'type': 'string'},
+            {"type": "string"},
           ],
         },
-        'flow': {
-          'anyOf': [
-            {'type': 'string'},
+        "flow": {
+          "anyOf": [
+            {"type": "string"},
             {
-              'type': 'string',
-              'enum': ['code', 'client'],
+              "type": "string",
+              "enum": ["code", "client"],
             }
           ],
         },
       },
-      'required': ['scheme'],
-      'additionalProperties': true,
+      "required": ["scheme"],
+      "additionalProperties": true,
     },
-    'securityScheme': {
-      'oneOf': [
-        {'\$ref': '#/definitions/noSecurityScheme'},
-        {'\$ref': '#/definitions/autoSecurityScheme'},
-        {'\$ref': '#/definitions/comboSecurityScheme'},
-        {'\$ref': '#/definitions/basicSecurityScheme'},
-        {'\$ref': '#/definitions/digestSecurityScheme'},
-        {'\$ref': '#/definitions/apiKeySecurityScheme'},
-        {'\$ref': '#/definitions/bearerSecurityScheme'},
-        {'\$ref': '#/definitions/pskSecurityScheme'},
-        {'\$ref': '#/definitions/oAuth2SecurityScheme'},
-        {'\$ref': '#/definitions/additionalSecurityScheme'},
+    "securityScheme": {
+      "oneOf": [
+        {"\$ref": "#/definitions/noSecurityScheme"},
+        {"\$ref": "#/definitions/autoSecurityScheme"},
+        {"\$ref": "#/definitions/comboSecurityScheme"},
+        {"\$ref": "#/definitions/basicSecurityScheme"},
+        {"\$ref": "#/definitions/digestSecurityScheme"},
+        {"\$ref": "#/definitions/apiKeySecurityScheme"},
+        {"\$ref": "#/definitions/bearerSecurityScheme"},
+        {"\$ref": "#/definitions/pskSecurityScheme"},
+        {"\$ref": "#/definitions/oAuth2SecurityScheme"},
+        {"\$ref": "#/definitions/additionalSecurityScheme"},
       ],
     },
   },
-  'type': 'object',
-  'properties': {
-    'id': {'type': 'string', 'format': 'uri'},
-    'title': {'\$ref': '#/definitions/title'},
-    'titles': {'\$ref': '#/definitions/titles'},
-    'properties': {
-      'type': 'object',
-      'additionalProperties': {'\$ref': '#/definitions/property_element'},
+  "type": "object",
+  "properties": {
+    "id": {"type": "string", "format": "uri"},
+    "title": {"\$ref": "#/definitions/title"},
+    "titles": {"\$ref": "#/definitions/titles"},
+    "properties": {
+      "type": "object",
+      "additionalProperties": {"\$ref": "#/definitions/property_element"},
     },
-    'actions': {
-      'type': 'object',
-      'additionalProperties': {'\$ref': '#/definitions/action_element'},
+    "actions": {
+      "type": "object",
+      "additionalProperties": {"\$ref": "#/definitions/action_element"},
     },
-    'events': {
-      'type': 'object',
-      'additionalProperties': {'\$ref': '#/definitions/event_element'},
+    "events": {
+      "type": "object",
+      "additionalProperties": {"\$ref": "#/definitions/event_element"},
     },
-    'description': {'\$ref': '#/definitions/description'},
-    'descriptions': {'\$ref': '#/definitions/descriptions'},
-    'version': {
-      'type': 'object',
-      'properties': {
-        'instance': {'type': 'string'},
+    "description": {"\$ref": "#/definitions/description"},
+    "descriptions": {"\$ref": "#/definitions/descriptions"},
+    "version": {
+      "type": "object",
+      "properties": {
+        "instance": {"type": "string"},
       },
-      'required': ['instance'],
+      "required": ["instance"],
     },
-    'links': {
-      'type': 'array',
-      'items': {
-        'oneOf': [
-          {'\$ref': '#/definitions/link_element'},
-          {'\$ref': '#/definitions/icon_link_element'},
+    "links": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {"\$ref": "#/definitions/link_element"},
+          {"\$ref": "#/definitions/icon_link_element"},
         ],
       },
     },
-    'forms': {
-      'type': 'array',
-      'minItems': 1,
-      'items': {'\$ref': '#/definitions/form_element_root'},
+    "forms": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"\$ref": "#/definitions/form_element_root"},
     },
-    'base': {'\$ref': '#/definitions/anyUri'},
-    'securityDefinitions': {
-      'type': 'object',
-      'minProperties': 1,
-      'additionalProperties': {'\$ref': '#/definitions/securityScheme'},
+    "base": {"\$ref": "#/definitions/anyUri"},
+    "securityDefinitions": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {"\$ref": "#/definitions/securityScheme"},
     },
-    'schemaDefinitions': {
-      'type': 'object',
-      'minProperties': 1,
-      'additionalProperties': {'\$ref': '#/definitions/dataSchema'},
+    "schemaDefinitions": {
+      "type": "object",
+      "minProperties": 1,
+      "additionalProperties": {"\$ref": "#/definitions/dataSchema"},
     },
-    'support': {'\$ref': '#/definitions/anyUri'},
-    'created': {'type': 'string', 'format': 'date-time'},
-    'modified': {'type': 'string', 'format': 'date-time'},
-    'profile': {
-      'oneOf': [
-        {'\$ref': '#/definitions/anyUri'},
+    "support": {"\$ref": "#/definitions/anyUri"},
+    "created": {"type": "string", "format": "date-time"},
+    "modified": {"type": "string", "format": "date-time"},
+    "profile": {
+      "oneOf": [
+        {"\$ref": "#/definitions/anyUri"},
         {
-          'type': 'array',
-          'minItems': 1,
-          'items': {'\$ref': '#/definitions/anyUri'},
+          "type": "array",
+          "minItems": 1,
+          "items": {"\$ref": "#/definitions/anyUri"},
         }
       ],
     },
-    'security': {
-      'oneOf': [
-        {'type': 'string'},
+    "security": {
+      "oneOf": [
+        {"type": "string"},
         {
-          'type': 'array',
-          'minItems': 1,
-          'items': {'type': 'string'},
+          "type": "array",
+          "minItems": 1,
+          "items": {"type": "string"},
         }
       ],
     },
-    'uriVariables': {
-      'type': 'object',
-      'additionalProperties': {'\$ref': '#/definitions/dataSchema'},
+    "uriVariables": {
+      "type": "object",
+      "additionalProperties": {"\$ref": "#/definitions/dataSchema"},
     },
-    '@type': {'\$ref': '#/definitions/type_declaration'},
-    '@context': {'\$ref': '#/definitions/thing-context'},
+    "@type": {"\$ref": "#/definitions/type_declaration"},
+    "@context": {"\$ref": "#/definitions/thing-context"},
   },
-  'required': ['title', 'security', 'securityDefinitions', '@context'],
-  'additionalProperties': true,
+  "required": ["title", "security", "securityDefinitions", "@context"],
+  "additionalProperties": true,
 };

--- a/lib/src/definitions/validation/validation_exception.dart
+++ b/lib/src/definitions/validation/validation_exception.dart
@@ -14,6 +14,6 @@ class ValidationException implements Exception {
 
   @override
   String toString() {
-    return 'ValidationException: $message';
+    return "ValidationException: $message";
   }
 }

--- a/lib/src/definitions/version_info.dart
+++ b/lib/src/definitions/version_info.dart
@@ -1,6 +1,6 @@
-import 'package:curie/curie.dart';
+import "package:curie/curie.dart";
 
-import 'extensions/json_parser.dart';
+import "extensions/json_parser.dart";
 
 /// Metadata of a Thing that provides version information about the TD document.
 ///
@@ -22,8 +22,8 @@ class VersionInfo {
   ) {
     final Set<String> parsedFields = {};
 
-    final instance = json.parseRequiredField<String>('instance', parsedFields);
-    final model = json.parseField<String>('instance', parsedFields);
+    final instance = json.parseRequiredField<String>("instance", parsedFields);
+    final model = json.parseField<String>("instance", parsedFields);
     final additionalFields =
         json.parseAdditionalFields(prefixMapping, parsedFields);
 

--- a/lib/src/scripting_api/consumed_thing.dart
+++ b/lib/src/scripting_api/consumed_thing.dart
@@ -4,11 +4,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../definitions/thing_description.dart';
-import 'interaction_input.dart';
-import 'interaction_output.dart';
-import 'subscription.dart';
-import 'types.dart';
+import "../definitions/thing_description.dart";
+import "interaction_input.dart";
+import "interaction_output.dart";
+import "subscription.dart";
+import "types.dart";
 
 /// User provided callback that is given an argument of type [InteractionOutput]
 /// and is used for observing Property changes and handling Event notifications.

--- a/lib/src/scripting_api/data_schema_value.dart
+++ b/lib/src/scripting_api/data_schema_value.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:collection/collection.dart';
-import 'package:meta/meta.dart';
+import "package:collection/collection.dart";
+import "package:meta/meta.dart";
 
 /// Value corresponding to a WoT DataSchema as specified in [section 7.1]
 /// of the [WoT Scripting API] specification.

--- a/lib/src/scripting_api/discovery/thing_discovery.dart
+++ b/lib/src/scripting_api/discovery/thing_discovery.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../../definitions/thing_description.dart';
-import 'thing_filter.dart';
+import "../../definitions/thing_description.dart";
+import "thing_filter.dart";
 
 /// Provides the properties and methods controlling the discovery process.
 ///

--- a/lib/src/scripting_api/exposed_thing.dart
+++ b/lib/src/scripting_api/exposed_thing.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../definitions/thing_description.dart';
-import 'interaction_input.dart';
-import 'interaction_output.dart';
+import "../definitions/thing_description.dart";
+import "interaction_input.dart";
+import "interaction_output.dart";
 
 /// A function that is called when an external request for reading a Property is
 /// received and defines what to do with such requests.

--- a/lib/src/scripting_api/interaction_input.dart
+++ b/lib/src/scripting_api/interaction_input.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:meta/meta.dart';
+import "package:meta/meta.dart";
 
-import 'data_schema_value.dart';
+import "data_schema_value.dart";
 
 /// The (optional) input for an interaction.
 ///
@@ -34,7 +34,7 @@ sealed class InteractionInput {
     final dataSchemaValue = ArrayValue.tryParse(value);
 
     if (dataSchemaValue == null) {
-      throw const FormatException('Input contained invalid array element.');
+      throw const FormatException("Input contained invalid array element.");
     }
 
     return DataSchemaValueInput(dataSchemaValue);
@@ -44,7 +44,7 @@ sealed class InteractionInput {
     final dataSchemaValue = ObjectValue.tryParse(value);
 
     if (dataSchemaValue == null) {
-      throw const FormatException('Input contained invalid map entry.');
+      throw const FormatException("Input contained invalid map entry.");
     }
 
     return DataSchemaValueInput(dataSchemaValue);

--- a/lib/src/scripting_api/interaction_output.dart
+++ b/lib/src/scripting_api/interaction_output.dart
@@ -4,10 +4,10 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:typed_data';
+import "dart:typed_data";
 
-import '../definitions/data_schema.dart';
-import '../definitions/form.dart';
+import "../definitions/data_schema.dart";
+import "../definitions/form.dart";
 
 /// Exposes the data obtained by Thing interactions.
 ///

--- a/lib/src/scripting_api/subscription.dart
+++ b/lib/src/scripting_api/subscription.dart
@@ -4,9 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../definitions/form.dart';
-import '../definitions/interaction_affordances/interaction_affordance.dart';
-import '../definitions/operation_type.dart';
+import "../definitions/form.dart";
+import "../definitions/interaction_affordances/interaction_affordance.dart";
+import "../definitions/operation_type.dart";
 
 /// [Exception] that is thrown when error during the unsubscribe process occurs.
 class UnsubscribeException implements Exception {
@@ -16,7 +16,7 @@ class UnsubscribeException implements Exception {
   final String _message;
 
   @override
-  String toString() => 'UnsubscribeException: $_message';
+  String toString() => "UnsubscribeException: $_message";
 }
 
 /// Indicates the type of the subscription.
@@ -83,7 +83,7 @@ Form findUnsubscribeForm(
   final unsubscribeForm = _findFormByScoring(interaction, form, operationType);
 
   if (unsubscribeForm == null) {
-    throw UnsubscribeException('Could not find matching form for unsubscribe');
+    throw UnsubscribeException("Could not find matching form for unsubscribe");
   }
 
   return unsubscribeForm;

--- a/lib/src/scripting_api/types.dart
+++ b/lib/src/scripting_api/types.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'interaction_input.dart';
-import 'interaction_output.dart';
+import "interaction_input.dart";
+import "interaction_output.dart";
 
 /// Maps multiple [InteractionOutput]s to property names.
 ///

--- a/lib/src/scripting_api/wot.dart
+++ b/lib/src/scripting_api/wot.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import '../definitions/thing_description.dart';
-import 'consumed_thing.dart';
-import 'discovery/discovery_method.dart';
-import 'discovery/thing_discovery.dart';
-import 'discovery/thing_filter.dart';
-import 'exposed_thing.dart';
-import 'types.dart';
+import "../definitions/thing_description.dart";
+import "consumed_thing.dart";
+import "discovery/discovery_method.dart";
+import "discovery/thing_discovery.dart";
+import "discovery/thing_filter.dart";
+import "exposed_thing.dart";
+import "types.dart";
 
 /// Interface for a [WoT] runtime.
 ///
@@ -62,10 +62,10 @@ abstract interface class WoT {
   /// for retrieving information about its current state (i.e., whether it is
   /// still [ThingDiscovery.active]).
   @Deprecated(
-    'The discover method is curently in the process of being adjusted to the '
-    'latest Scripting API version and is therefore subject to change. '
-    'For direct and directory discovery, please refer to the '
-    'requestThingDescription and exploreDirectory methods instead.',
+    "The discover method is curently in the process of being adjusted to the "
+    "latest Scripting API version and is therefore subject to change. "
+    "For direct and directory discovery, please refer to the "
+    "requestThingDescription and exploreDirectory methods instead.",
   )
   ThingDiscovery discover(
     Uri url, {

--- a/test/binding_coap/binding_coap_test.dart
+++ b/test/binding_coap/binding_coap_test.dart
@@ -4,23 +4,23 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dart_wot/dart_wot.dart';
-import 'package:mockito/annotations.dart';
-import 'package:test/test.dart';
-import 'binding_coap_test.mocks.dart';
+import "package:dart_wot/dart_wot.dart";
+import "package:mockito/annotations.dart";
+import "package:test/test.dart";
+import "binding_coap_test.mocks.dart";
 
 @GenerateMocks([ExposedThing])
 void main() {
-  group('CoAP Binding Tests', () {
+  group("CoAP Binding Tests", () {
     setUp(() {
       // Additional setup goes here.
     });
 
-    test('Server tests', () {
+    test("Server tests", () {
       final defaultServer = CoapServer();
 
       expect(defaultServer.port, 5683);
-      expect(defaultServer.scheme, 'coap');
+      expect(defaultServer.scheme, "coap");
 
       expect(
         () async => defaultServer.start(),
@@ -42,7 +42,7 @@ void main() {
       expect(customServer.preferredBlockSize, 64);
     });
 
-    test('ClientFactory tests', () async {
+    test("ClientFactory tests", () async {
       final defaultClientFactory = CoapClientFactory();
 
       expect(defaultClientFactory.coapConfig, null);

--- a/test/binding_coap/coap_vocabulary_test.dart
+++ b/test/binding_coap/coap_vocabulary_test.dart
@@ -4,61 +4,61 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:coap/coap.dart';
-import 'package:dart_wot/dart_wot.dart';
-import 'package:dart_wot/src/binding_coap/coap_definitions.dart';
-import 'package:dart_wot/src/binding_coap/coap_extensions.dart';
-import 'package:dart_wot/src/definitions/validation/validation_exception.dart';
-import 'package:test/test.dart';
+import "package:coap/coap.dart";
+import "package:dart_wot/dart_wot.dart";
+import "package:dart_wot/src/binding_coap/coap_definitions.dart";
+import "package:dart_wot/src/binding_coap/coap_extensions.dart";
+import "package:dart_wot/src/definitions/validation/validation_exception.dart";
+import "package:test/test.dart";
 
 void main() {
-  group('CoAP Vocabulary Tests', () {
-    test('Should deserialize CoAP Forms', () async {
+  group("CoAP Vocabulary Tests", () {
+    test("Should deserialize CoAP Forms", () async {
       const thingDescriptionJson = {
-        '@context': [
-          'https://www.w3.org/2022/wot/td/v1.1',
-          {'cov': 'http://www.example.org/coap-binding#'},
+        "@context": [
+          "https://www.w3.org/2022/wot/td/v1.1",
+          {"cov": "http://www.example.org/coap-binding#"},
         ],
-        'title': 'Test Thing',
-        'properties': {
-          'status': {
-            'forms': [
+        "title": "Test Thing",
+        "properties": {
+          "status": {
+            "forms": [
               {
-                'href': 'coap://example.org',
-                'cov:method': 'iPATCH',
-                'contentType': 'application/cbor',
-                'cov:contentFormat': 60,
-                'cov:accept': 60,
-                'cov:blockwise': {
-                  'cov:block1Size': 32,
-                  'cov:block2Size': 64,
+                "href": "coap://example.org",
+                "cov:method": "iPATCH",
+                "contentType": "application/cbor",
+                "cov:contentFormat": 60,
+                "cov:accept": 60,
+                "cov:blockwise": {
+                  "cov:block1Size": 32,
+                  "cov:block2Size": 64,
                 },
-                'response': {
-                  'contentType': 'application/cbor',
-                  'cov:contentFormat': 60,
+                "response": {
+                  "contentType": "application/cbor",
+                  "cov:contentFormat": 60,
                 },
               },
               {
-                'href': 'coap://example.org',
-                'cov:blockwise': {
-                  'cov:block1Size': 5000,
-                  'cov:block2Size': 4096,
+                "href": "coap://example.org",
+                "cov:blockwise": {
+                  "cov:block1Size": 5000,
+                  "cov:block2Size": 4096,
                 },
               },
             ],
           },
         },
-        'securityDefinitions': {
-          'nosec_sc': {'scheme': 'nosec'},
+        "securityDefinitions": {
+          "nosec_sc": {"scheme": "nosec"},
         },
-        'security': ['nosec_sc'],
+        "security": ["nosec_sc"],
       };
 
       final thingDescription = ThingDescription.fromJson(thingDescriptionJson);
-      final property = thingDescription.properties['status'];
+      final property = thingDescription.properties["status"];
       final form = property?.forms[0];
 
-      expect(form?.href, Uri.parse('coap://example.org'));
+      expect(form?.href, Uri.parse("coap://example.org"));
       expect(form?.method, CoapRequestMethod.ipatch);
       expect(form?.contentFormat, CoapMediaType.applicationCbor);
       expect(form?.accept, CoapMediaType.applicationCbor);

--- a/test/binding_http/http_test.dart
+++ b/test/binding_http/http_test.dart
@@ -4,23 +4,23 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dart_wot/dart_wot.dart';
-import 'package:mockito/annotations.dart';
-import 'package:test/test.dart';
-import 'http_test.mocks.dart';
+import "package:dart_wot/dart_wot.dart";
+import "package:mockito/annotations.dart";
+import "package:test/test.dart";
+import "http_test.mocks.dart";
 
 @GenerateMocks([ExposedThing])
 void main() {
-  group('HTTP tests', () {
+  group("HTTP tests", () {
     setUp(() {
       // Additional setup goes here.
     });
 
-    test('Server tests', () {
+    test("Server tests", () {
       final defaultServer = HttpServer(null);
 
       expect(defaultServer.port, 80);
-      expect(defaultServer.scheme, 'http');
+      expect(defaultServer.scheme, "http");
 
       expect(
         () async => defaultServer.start(),
@@ -38,24 +38,24 @@ void main() {
       final customServer1 = HttpServer(HttpConfig(secure: true));
 
       expect(customServer1.port, 443);
-      expect(customServer1.scheme, 'https');
+      expect(customServer1.scheme, "https");
 
       final customServer2 = HttpServer(HttpConfig(port: 9001, secure: true));
 
       expect(customServer2.port, 9001);
-      expect(customServer2.scheme, 'https');
+      expect(customServer2.scheme, "https");
     });
 
     test(
-      'HTTP Security Schemes',
+      "HTTP Security Schemes",
       () async {
-        const username = 'username';
-        const password = 'password';
-        const token = 'thisIsTheMostAwesomeTokenEver!';
+        const username = "username";
+        const password = "password";
+        const token = "thisIsTheMostAwesomeTokenEver!";
 
         // TODO(JKRhb): Does not have an effect in the TD yet (and is negotiated
         //              automatically by http_auth instead)
-        const qop = 'auth-int';
+        const qop = "auth-int";
 
         const thingDescriptionJson = '''
       {
@@ -106,11 +106,11 @@ void main() {
         final parsedTd = ThingDescription(thingDescriptionJson);
 
         final Map<String, BasicCredentials> basicCredentialsStore = {
-          'httpbin.org': BasicCredentials(username, password),
+          "httpbin.org": BasicCredentials(username, password),
         };
 
         final Map<String, BearerCredentials> bearerCredentialsStore = {
-          'httpbin.org': BearerCredentials(token),
+          "httpbin.org": BearerCredentials(token),
         };
 
         Future<BasicCredentials?> basicCredentialsCallback(
@@ -139,17 +139,17 @@ void main() {
         final wot = await servient.start();
 
         final consumedThing = await wot.consume(parsedTd);
-        final result = await consumedThing.readProperty('status');
+        final result = await consumedThing.readProperty("status");
         final value = await result.value();
-        expect(value, {'authenticated': true, 'user': username});
+        expect(value, {"authenticated": true, "user": username});
 
         // final result2 = await consumedThing.readProperty('status2');
         // final value2 = await result2.value();
         // expect(value2, {'authenticated': true, 'user': username});
 
-        final result3 = await consumedThing.readProperty('status3');
+        final result3 = await consumedThing.readProperty("status3");
         final value3 = await result3.value();
-        expect(value3, {'authenticated': true, 'token': token});
+        expect(value3, {"authenticated": true, "token": token});
       },
       skip: true,
     );

--- a/test/core/codec_test.dart
+++ b/test/core/codec_test.dart
@@ -4,20 +4,20 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
+import "dart:convert";
 
-import 'package:dart_wot/scripting_api.dart';
-import 'package:dart_wot/src/core/codecs/cbor_codec.dart';
-import 'package:dart_wot/src/core/codecs/json_codec.dart' as json_codec;
-import 'package:dart_wot/src/core/codecs/text_codec.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/scripting_api.dart";
+import "package:dart_wot/src/core/codecs/cbor_codec.dart";
+import "package:dart_wot/src/core/codecs/json_codec.dart" as json_codec;
+import "package:dart_wot/src/core/codecs/text_codec.dart";
+import "package:test/test.dart";
 
 void main() {
-  group('TextCodec should', () {
-    test('convert bytes to values and back', () {
+  group("TextCodec should", () {
+    test("convert bytes to values and back", () {
       final textCodec = TextCodec();
 
-      const testValue = 'foo';
+      const testValue = "foo";
       final testInput = utf8.encode(testValue);
 
       final convertedValue = textCodec.bytesToValue(testInput, null, {});
@@ -31,14 +31,14 @@ void main() {
       expect(convertedNullValue, []);
     });
 
-    test('reject unknown charsets', () {
+    test("reject unknown charsets", () {
       final textCodec = TextCodec();
 
-      const charsetParameters = {'charset': 'foobar'};
+      const charsetParameters = {"charset": "foobar"};
 
       expect(
         () =>
-            textCodec.bytesToValue(utf8.encode('foo'), null, charsetParameters),
+            textCodec.bytesToValue(utf8.encode("foo"), null, charsetParameters),
         throwsFormatException,
       );
 
@@ -53,11 +53,11 @@ void main() {
     });
   });
 
-  group('JsonCodec should', () {
-    test('convert bytes to values and back', () {
+  group("JsonCodec should", () {
+    test("convert bytes to values and back", () {
       final jsonCodec = json_codec.JsonCodec();
 
-      const testValue = 'foo';
+      const testValue = "foo";
       final testInput = utf8.encode('"$testValue"');
 
       final convertedValue = jsonCodec.bytesToValue(testInput, null, {});
@@ -72,11 +72,11 @@ void main() {
     });
   });
 
-  group('CborCodec should', () {
-    test('convert bytes to values and back', () {
+  group("CborCodec should", () {
+    test("convert bytes to values and back", () {
       final cborCodec = CborCodec();
       const testValue = {
-        'foo': ['bar', 'baz'],
+        "foo": ["bar", "baz"],
       };
 
       final convertedBytes = cborCodec

--- a/test/core/consumed_thing_test.dart
+++ b/test/core/consumed_thing_test.dart
@@ -4,25 +4,25 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dart_wot/dart_wot.dart';
-import 'package:dart_wot/src/definitions/security/apikey_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/basic_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/bearer_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/combo_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/digest_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/no_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/oauth2_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/psk_security_scheme.dart';
-import 'package:dart_wot/src/definitions/validation/validation_exception.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/dart_wot.dart";
+import "package:dart_wot/src/definitions/security/apikey_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/basic_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/bearer_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/combo_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/digest_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/no_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/oauth2_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/psk_security_scheme.dart";
+import "package:dart_wot/src/definitions/validation/validation_exception.dart";
+import "package:test/test.dart";
 
 void main() {
-  group('Consumed Thing Tests', () {
+  group("Consumed Thing Tests", () {
     setUp(() {
       // Additional setup goes here.
     });
 
-    test('Parse Interaction Affordances', () async {
+    test("Parse Interaction Affordances", () async {
       const thingDescriptionJson = '''
       {
         "@context": [
@@ -148,98 +148,98 @@ void main() {
       final parsedTd = ThingDescription(thingDescriptionJson);
 
       final security = parsedTd.security;
-      expect(security, ['nosec_sc']);
+      expect(security, ["nosec_sc"]);
 
-      expect(parsedTd.title, 'Test Thing');
-      expect(parsedTd.titles, {'en': 'Test Thing'});
-      expect(parsedTd.description, 'A Test Thing used for Testing.');
-      expect(parsedTd.descriptions, {'en': 'A Test Thing used for Testing.'});
+      expect(parsedTd.title, "Test Thing");
+      expect(parsedTd.titles, {"en": "Test Thing"});
+      expect(parsedTd.description, "A Test Thing used for Testing.");
+      expect(parsedTd.descriptions, {"en": "A Test Thing used for Testing."});
 
-      final statusProperty = parsedTd.properties['status'];
-      expect(statusProperty!.title, 'Status');
-      expect(statusProperty.titles!['en'], 'Status');
-      expect(statusProperty.description, 'Status of this Lamp');
-      expect(statusProperty.descriptions!['en'], 'Status of this Lamp');
+      final statusProperty = parsedTd.properties["status"];
+      expect(statusProperty!.title, "Status");
+      expect(statusProperty.titles!["en"], "Status");
+      expect(statusProperty.description, "Status of this Lamp");
+      expect(statusProperty.descriptions!["en"], "Status of this Lamp");
 
-      final toggleAction = parsedTd.actions['toggle'];
-      expect(toggleAction!.title, 'Toggle');
-      expect(toggleAction.titles!['en'], 'Toggle');
-      expect(toggleAction.description, 'Toggle this Lamp');
-      expect(toggleAction.descriptions!['en'], 'Toggle this Lamp');
+      final toggleAction = parsedTd.actions["toggle"];
+      expect(toggleAction!.title, "Toggle");
+      expect(toggleAction.titles!["en"], "Toggle");
+      expect(toggleAction.description, "Toggle this Lamp");
+      expect(toggleAction.descriptions!["en"], "Toggle this Lamp");
 
-      final eventAction = parsedTd.events['overheating'];
-      expect(eventAction!.title, 'Overheating');
-      expect(eventAction.titles!['en'], 'Overheating');
-      expect(eventAction.description, 'Overheating of this Lamp');
-      expect(eventAction.descriptions!['en'], 'Overheating of this Lamp');
+      final eventAction = parsedTd.events["overheating"];
+      expect(eventAction!.title, "Overheating");
+      expect(eventAction.titles!["en"], "Overheating");
+      expect(eventAction.description, "Overheating of this Lamp");
+      expect(eventAction.descriptions!["en"], "Overheating of this Lamp");
 
-      final nosecSc = parsedTd.securityDefinitions['nosec_sc'];
+      final nosecSc = parsedTd.securityDefinitions["nosec_sc"];
       expect(nosecSc is NoSecurityScheme, true);
-      expect(nosecSc?.proxy, Uri.parse('http://example.org'));
-      expect(nosecSc?.jsonLdType, ['Test']);
+      expect(nosecSc?.proxy, Uri.parse("http://example.org"));
+      expect(nosecSc?.jsonLdType, ["Test"]);
 
-      final basicSc = parsedTd.securityDefinitions['basic_sc'];
+      final basicSc = parsedTd.securityDefinitions["basic_sc"];
       expect(basicSc is BasicSecurityScheme, true);
-      expect(basicSc?.description, 'Test');
-      expect((basicSc as BasicSecurityScheme?)!.in_, 'query');
+      expect(basicSc?.description, "Test");
+      expect((basicSc as BasicSecurityScheme?)!.in_, "query");
 
-      final pskSc = parsedTd.securityDefinitions['psk_sc'];
+      final pskSc = parsedTd.securityDefinitions["psk_sc"];
       expect(pskSc is PskSecurityScheme, true);
-      expect((pskSc as PskSecurityScheme?)!.identity, 'Test');
+      expect((pskSc as PskSecurityScheme?)!.identity, "Test");
 
-      final apikeySc = parsedTd.securityDefinitions['apikey_sc'];
+      final apikeySc = parsedTd.securityDefinitions["apikey_sc"];
       expect(apikeySc is ApiKeySecurityScheme, true);
-      expect((apikeySc as ApiKeySecurityScheme?)!.name, 'Test');
-      expect(apikeySc!.in_, 'body');
+      expect((apikeySc as ApiKeySecurityScheme?)!.name, "Test");
+      expect(apikeySc!.in_, "body");
 
-      final digestSc = parsedTd.securityDefinitions['digest_sc'];
+      final digestSc = parsedTd.securityDefinitions["digest_sc"];
       expect(digestSc is DigestSecurityScheme, true);
-      expect((digestSc as DigestSecurityScheme?)!.name, 'Test');
-      expect(digestSc!.in_, 'cookie');
-      expect(digestSc.qop, 'auth-int');
+      expect((digestSc as DigestSecurityScheme?)!.name, "Test");
+      expect(digestSc!.in_, "cookie");
+      expect(digestSc.qop, "auth-int");
 
-      final bearerSc = parsedTd.securityDefinitions['bearer_sc'];
+      final bearerSc = parsedTd.securityDefinitions["bearer_sc"];
       expect(bearerSc is BearerSecurityScheme, true);
       expect(
         (bearerSc as BearerSecurityScheme?)!.authorization,
-        'http://example.org',
+        "http://example.org",
       );
-      expect(bearerSc!.name, 'Test');
-      expect(bearerSc.alg, 'ES256');
-      expect(bearerSc.format, 'jws');
-      expect(bearerSc.in_, 'uri');
+      expect(bearerSc!.name, "Test");
+      expect(bearerSc.alg, "ES256");
+      expect(bearerSc.format, "jws");
+      expect(bearerSc.in_, "uri");
 
-      final oauth2Sc = parsedTd.securityDefinitions['oauth2_sc'];
+      final oauth2Sc = parsedTd.securityDefinitions["oauth2_sc"];
       expect(oauth2Sc is OAuth2SecurityScheme, true);
       expect(
         (oauth2Sc as OAuth2SecurityScheme?)!.authorization,
-        'http://example.org',
+        "http://example.org",
       );
-      expect(oauth2Sc!.refresh, 'http://example.org');
-      expect(oauth2Sc.token, 'http://example.org');
-      expect(oauth2Sc.scopes, ['test']);
-      expect(oauth2Sc.flow, 'client');
+      expect(oauth2Sc!.refresh, "http://example.org");
+      expect(oauth2Sc.token, "http://example.org");
+      expect(oauth2Sc.scopes, ["test"]);
+      expect(oauth2Sc.flow, "client");
 
-      final comboSc1 = parsedTd.securityDefinitions['combo_sc1'];
+      final comboSc1 = parsedTd.securityDefinitions["combo_sc1"];
       expect(comboSc1 is ComboSecurityScheme, true);
       expect(
         (comboSc1 as ComboSecurityScheme?)!.allOf,
-        ['digest_sc', 'apikey_sc'],
+        ["digest_sc", "apikey_sc"],
       );
       expect(comboSc1!.oneOf, null);
 
-      final comboSc2 = parsedTd.securityDefinitions['combo_sc2'];
+      final comboSc2 = parsedTd.securityDefinitions["combo_sc2"];
       expect(comboSc2 is ComboSecurityScheme, true);
       expect(
         (comboSc2 as ComboSecurityScheme?)!.oneOf,
-        ['oauth2_sc', 'bearer_sc'],
+        ["oauth2_sc", "bearer_sc"],
       );
       expect(comboSc2!.allOf, null);
     });
   });
 
   test(
-    'Use of URI Template Variables',
+    "Use of URI Template Variables",
     () async {
       const thingDescriptionJson = '''
       {
@@ -287,21 +287,21 @@ void main() {
       final servient = Servient(clientFactories: [HttpClientFactory()]);
       final wot = await servient.start();
 
-      final uriVariables = {'value': 'SFRUUEJJTiBpcyBhd2Vzb21l'};
+      final uriVariables = {"value": "SFRUUEJJTiBpcyBhd2Vzb21l"};
 
       final consumedThing = await wot.consume(parsedTd);
       final result = await consumedThing.readProperty(
-        'status',
+        "status",
         uriVariables: uriVariables,
       );
       final value = await result.value();
-      expect(value, 'HTTPBIN is awesome');
+      expect(value, "HTTPBIN is awesome");
 
       // status2 expects an integer instead of a String and throws an error if
       // the same value is provided as an input
       expect(
         consumedThing.readProperty(
-          'status2',
+          "status2",
           uriVariables: uriVariables,
         ),
         throwsA(const TypeMatcher<ValidationException>()),

--- a/test/core/content_serdes_test.dart
+++ b/test/core/content_serdes_test.dart
@@ -4,26 +4,26 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:curie/curie.dart';
-import 'package:dart_wot/src/core/codecs/json_codec.dart';
-import 'package:dart_wot/src/core/content.dart';
-import 'package:dart_wot/src/core/content_serdes.dart';
-import 'package:dart_wot/src/definitions/data_schema.dart';
-import 'package:dart_wot/src/scripting_api/data_schema_value.dart';
-import 'package:test/test.dart';
+import "package:curie/curie.dart";
+import "package:dart_wot/src/core/codecs/json_codec.dart";
+import "package:dart_wot/src/core/content.dart";
+import "package:dart_wot/src/core/content_serdes.dart";
+import "package:dart_wot/src/definitions/data_schema.dart";
+import "package:dart_wot/src/scripting_api/data_schema_value.dart";
+import "package:test/test.dart";
 
 Content _getTestContent(String input) {
-  return Content('application/json', Stream<List<int>>.value(input.codeUnits));
+  return Content("application/json", Stream<List<int>>.value(input.codeUnits));
 }
 
 void main() {
-  group('ContentSerdes should', () {
-    test('validate Content', () async {
+  group("ContentSerdes should", () {
+    test("validate Content", () async {
       final contentSerdes = ContentSerdes();
 
-      final testContent1 = _getTestContent('42');
+      final testContent1 = _getTestContent("42");
       final successfulSchema = DataSchema.fromJson(
-        <String, dynamic>{'type': 'number'},
+        <String, dynamic>{"type": "number"},
         PrefixMapping(),
       );
 
@@ -32,9 +32,9 @@ void main() {
         DataSchemaValue.fromInteger(42),
       );
 
-      final testContent2 = _getTestContent('42');
+      final testContent2 = _getTestContent("42");
       final failingSchema = DataSchema.fromJson(
-        <String, dynamic>{'type': 'string'},
+        <String, dynamic>{"type": "string"},
         PrefixMapping(),
       );
 
@@ -51,87 +51,87 @@ void main() {
         throwsA(const TypeMatcher<ContentSerdesException>()),
       );
 
-      final testContent3 = _getTestContent('');
+      final testContent3 = _getTestContent("");
       expect(
         await contentSerdes.contentToValue(testContent3, null),
         null,
       );
     });
-    test('support registration of new Codecs', () async {
+    test("support registration of new Codecs", () async {
       final contentSerdes = ContentSerdes();
 
       expect(
         contentSerdes.supportedMediaTypes,
         [
-          'application/json',
-          'application/cbor',
-          'application/link-format',
-          'text/plain',
+          "application/json",
+          "application/cbor",
+          "application/link-format",
+          "text/plain",
         ],
       );
 
       expect(
         contentSerdes.offeredMediaTypes,
-        ['application/json', 'application/cbor'],
+        ["application/json", "application/cbor"],
       );
 
       expect(
-        () => contentSerdes.addOfferedMediaType('application/xml'),
+        () => contentSerdes.addOfferedMediaType("application/xml"),
         throwsArgumentError,
       );
 
-      contentSerdes.addOfferedMediaType('application/td+json; charset=utf-8');
+      contentSerdes.addOfferedMediaType("application/td+json; charset=utf-8");
 
       expect(
         contentSerdes.offeredMediaTypes,
         [
-          'application/json',
-          'application/cbor',
-          'application/td+json; charset=utf-8',
+          "application/json",
+          "application/cbor",
+          "application/td+json; charset=utf-8",
         ],
       );
 
-      contentSerdes.removeOfferedMediaType('application/json');
+      contentSerdes.removeOfferedMediaType("application/json");
 
       expect(
         contentSerdes.offeredMediaTypes,
         [
-          'application/cbor',
-          'application/td+json; charset=utf-8',
+          "application/cbor",
+          "application/td+json; charset=utf-8",
         ],
       );
 
       contentSerdes
-        ..assignCodec('application/xml', JsonCodec())
-        ..addOfferedMediaType('application/xml');
+        ..assignCodec("application/xml", JsonCodec())
+        ..addOfferedMediaType("application/xml");
 
       expect(
         contentSerdes.supportedMediaTypes,
         [
-          'application/json',
-          'application/cbor',
-          'application/link-format',
-          'text/plain',
-          'application/xml',
+          "application/json",
+          "application/cbor",
+          "application/link-format",
+          "text/plain",
+          "application/xml",
         ],
       );
 
       expect(
         contentSerdes.offeredMediaTypes,
         [
-          'application/cbor',
-          'application/td+json; charset=utf-8',
-          'application/xml',
+          "application/cbor",
+          "application/td+json; charset=utf-8",
+          "application/xml",
         ],
       );
 
       expect(
-        () => contentSerdes.assignCodec('foo', JsonCodec()),
+        () => contentSerdes.assignCodec("foo", JsonCodec()),
         throwsArgumentError,
       );
     });
 
-    test('return a Content object with an empty Stream for undefined values',
+    test("return a Content object with an empty Stream for undefined values",
         () async {
       final contentSerdes = ContentSerdes();
       final content = contentSerdes.valueToContent(null, null);
@@ -139,7 +139,7 @@ void main() {
       expect(await content.body.isEmpty, isTrue);
     });
 
-    test('reject undefined DataSchemaValues if a DataSchema is given',
+    test("reject undefined DataSchemaValues if a DataSchema is given",
         () async {
       final contentSerdes = ContentSerdes();
 
@@ -147,15 +147,15 @@ void main() {
         () => contentSerdes.valueToContent(
           null,
           // FIXME(JKRhb): Should not be necessary to use fromJson here
-          DataSchema.fromJson({'type': 'object'}, PrefixMapping()),
+          DataSchema.fromJson({"type": "object"}, PrefixMapping()),
         ),
         throwsA(isA<ContentSerdesException>()),
       );
     });
 
-    test('convert DataSchemaValues to Content', () async {
+    test("convert DataSchemaValues to Content", () async {
       final contentSerdes = ContentSerdes();
-      const inputValue = 'foo';
+      const inputValue = "foo";
 
       final content = contentSerdes.valueToContent(
         DataSchemaValue.fromString(inputValue),
@@ -163,7 +163,7 @@ void main() {
       );
 
       expect(await content.toByteList(), [34, 102, 111, 111, 34]);
-      expect(content.type, 'application/json');
+      expect(content.type, "application/json");
     });
   });
 }

--- a/test/core/content_test.dart
+++ b/test/core/content_test.dart
@@ -4,20 +4,20 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
+import "dart:convert";
 
-import 'package:dart_wot/dart_wot.dart';
-import 'package:dart_wot/src/core/content.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/dart_wot.dart";
+import "package:dart_wot/src/core/content.dart";
+import "package:test/test.dart";
 
 void main() {
-  group('Content should', () {
-    group('be able to be instantiated using fromInteractionInput() with', () {
-      test('null', () async {
+  group("Content should", () {
+    group("be able to be instantiated using fromInteractionInput() with", () {
+      test("null", () async {
         final contentSerdes = ContentSerdes();
         final content = Content.fromInteractionInput(
           null,
-          'application/json',
+          "application/json",
           contentSerdes,
           null,
         );
@@ -25,15 +25,15 @@ void main() {
         expect(await content.body.isEmpty, isTrue);
       });
 
-      test('a DataSchemaValueInput', () async {
+      test("a DataSchemaValueInput", () async {
         final contentSerdes = ContentSerdes();
-        const inputValue = 'foo';
+        const inputValue = "foo";
         final input =
             DataSchemaValueInput(DataSchemaValue.fromString(inputValue));
 
         final content = Content.fromInteractionInput(
           input,
-          'application/json',
+          "application/json",
           contentSerdes,
           null,
         );
@@ -41,7 +41,7 @@ void main() {
         expect(await content.toByteList(), [34, 102, 111, 111, 34]);
       });
 
-      test('a StreamInput', () async {
+      test("a StreamInput", () async {
         final contentSerdes = ContentSerdes();
         const inputValue = '"foo"';
         final byteList = [utf8.encode(inputValue)];
@@ -49,7 +49,7 @@ void main() {
 
         final content = Content.fromInteractionInput(
           input,
-          'application/json',
+          "application/json",
           contentSerdes,
           null,
         );

--- a/test/core/dart_wot_test.dart
+++ b/test/core/dart_wot_test.dart
@@ -4,31 +4,31 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dart_wot/dart_wot.dart';
-import 'package:dart_wot/src/definitions/link.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/dart_wot.dart";
+import "package:dart_wot/src/definitions/link.dart";
+import "package:test/test.dart";
 
 // TODO(JKRhb): Add proper tests
 
 void main() {
-  group('Exposed Thing Tests', () {
+  group("Exposed Thing Tests", () {
     setUp(() {
       // Additional setup goes here.
     });
 
-    test('Parse incomplete Thing Description', () async {
+    test("Parse incomplete Thing Description", () async {
       final servient = Servient();
       final wot = await servient.start();
       final Map<String, dynamic> exposedThingInit = <String, dynamic>{
-        '@context': 'https://www.w3.org/2022/wot/td/v1.1',
-        'title': 'Test Thing',
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "title": "Test Thing",
       };
       final dynamic exposedThing = await wot.produce(exposedThingInit);
       // ignore: avoid_dynamic_calls
-      expect(exposedThing.id.startsWith('urn:uuid:'), true);
+      expect(exposedThing.id.startsWith("urn:uuid:"), true);
     });
 
-    test('Parse Thing Description', () {
+    test("Parse Thing Description", () {
       const thingDescriptionJson = '''
       {
         "@context": ["http://www.w3.org/ns/td", {"@language": "de"}],
@@ -67,53 +67,53 @@ void main() {
       ''';
       final parsedTd = ThingDescription(thingDescriptionJson);
 
-      expect(parsedTd.title, 'Test Thing');
+      expect(parsedTd.title, "Test Thing");
 
       final firstContextEntry = parsedTd.context[0];
       final secondContextEntry = parsedTd.context[1];
 
       expect(firstContextEntry.key, null);
-      expect(firstContextEntry.value, 'http://www.w3.org/ns/td');
-      expect(secondContextEntry.key, '@language');
-      expect(secondContextEntry.value, 'de');
+      expect(firstContextEntry.value, "http://www.w3.org/ns/td");
+      expect(secondContextEntry.key, "@language");
+      expect(secondContextEntry.value, "de");
 
-      expect(parsedTd.security, ['nosec_sc']);
-      final securityDefinition = parsedTd.securityDefinitions['nosec_sc']!;
-      expect(securityDefinition.scheme, 'nosec');
+      expect(parsedTd.security, ["nosec_sc"]);
+      final securityDefinition = parsedTd.securityDefinitions["nosec_sc"]!;
+      expect(securityDefinition.scheme, "nosec");
 
       final parsedLink = parsedTd.links[0];
-      expect(parsedLink.href, Uri.parse('https://example.org'));
-      expect(parsedLink.rel, 'test');
-      expect(parsedLink.anchor, Uri.parse('https://example.org'));
-      expect(parsedLink.type, 'test');
-      expect(parsedLink.sizes, '42');
-      expect(parsedLink.hreflang, ['de']);
-      expect(parsedLink.additionalFields['test'], 'test');
+      expect(parsedLink.href, Uri.parse("https://example.org"));
+      expect(parsedLink.rel, "test");
+      expect(parsedLink.anchor, Uri.parse("https://example.org"));
+      expect(parsedLink.type, "test");
+      expect(parsedLink.sizes, "42");
+      expect(parsedLink.hreflang, ["de"]);
+      expect(parsedLink.additionalFields["test"], "test");
 
       final secondParsedLink = parsedTd.links[1];
-      expect(secondParsedLink.hreflang, ['de', 'en']);
+      expect(secondParsedLink.hreflang, ["de", "en"]);
     });
 
-    test('Link Tests', () {
+    test("Link Tests", () {
       final link = Link(
-        'https://example.org',
-        type: 'test',
-        rel: 'test',
-        anchor: 'https://example.org',
-        sizes: '42',
-        additionalFields: <String, dynamic>{'test': 'test'},
-        hreflang: ['de'],
+        "https://example.org",
+        type: "test",
+        rel: "test",
+        anchor: "https://example.org",
+        sizes: "42",
+        additionalFields: <String, dynamic>{"test": "test"},
+        hreflang: ["de"],
       );
-      expect(link.href, Uri.parse('https://example.org'));
-      expect(link.rel, 'test');
-      expect(link.anchor, Uri.parse('https://example.org'));
-      expect(link.hreflang, ['de']);
-      expect(link.type, 'test');
-      expect(link.sizes, '42');
-      expect(link.additionalFields['test'], 'test');
+      expect(link.href, Uri.parse("https://example.org"));
+      expect(link.rel, "test");
+      expect(link.anchor, Uri.parse("https://example.org"));
+      expect(link.hreflang, ["de"]);
+      expect(link.type, "test");
+      expect(link.sizes, "42");
+      expect(link.additionalFields["test"], "test");
 
-      final link2 = Link('https://example.org');
-      expect(link2.href, Uri.parse('https://example.org'));
+      final link2 = Link("https://example.org");
+      expect(link2.href, Uri.parse("https://example.org"));
       expect(link2.anchor, null);
       expect(link2.additionalFields, <String, dynamic>{});
     });

--- a/test/core/definitions_test.dart
+++ b/test/core/definitions_test.dart
@@ -4,36 +4,36 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
+import "dart:convert";
 
-import 'package:curie/curie.dart';
-import 'package:dart_wot/dart_wot.dart';
-import 'package:dart_wot/src/definitions/additional_expected_response.dart';
-import 'package:dart_wot/src/definitions/data_schema.dart';
-import 'package:dart_wot/src/definitions/expected_response.dart';
-import 'package:dart_wot/src/definitions/extensions/json_parser.dart';
-import 'package:dart_wot/src/definitions/interaction_affordances/action.dart';
-import 'package:dart_wot/src/definitions/interaction_affordances/interaction_affordance.dart';
-import 'package:dart_wot/src/definitions/interaction_affordances/property.dart';
-import 'package:dart_wot/src/definitions/operation_type.dart';
-import 'package:dart_wot/src/definitions/security/auto_security_scheme.dart';
-import 'package:dart_wot/src/definitions/security/no_security_scheme.dart';
-import 'package:dart_wot/src/definitions/validation/thing_description_schema.dart';
-import 'package:dart_wot/src/definitions/validation/validation_exception.dart';
-import 'package:test/test.dart';
+import "package:curie/curie.dart";
+import "package:dart_wot/dart_wot.dart";
+import "package:dart_wot/src/definitions/additional_expected_response.dart";
+import "package:dart_wot/src/definitions/data_schema.dart";
+import "package:dart_wot/src/definitions/expected_response.dart";
+import "package:dart_wot/src/definitions/extensions/json_parser.dart";
+import "package:dart_wot/src/definitions/interaction_affordances/action.dart";
+import "package:dart_wot/src/definitions/interaction_affordances/interaction_affordance.dart";
+import "package:dart_wot/src/definitions/interaction_affordances/property.dart";
+import "package:dart_wot/src/definitions/operation_type.dart";
+import "package:dart_wot/src/definitions/security/auto_security_scheme.dart";
+import "package:dart_wot/src/definitions/security/no_security_scheme.dart";
+import "package:dart_wot/src/definitions/validation/thing_description_schema.dart";
+import "package:dart_wot/src/definitions/validation/validation_exception.dart";
+import "package:test/test.dart";
 
 class _InvalidInteractionAffordance extends InteractionAffordance {
   _InvalidInteractionAffordance(super.thingDescription);
 }
 
 void main() {
-  group('Definitions', () {
+  group("Definitions", () {
     setUp(() {
       // Additional setup goes here.
     });
 
-    test('should not accept invalid Thing Descriptions', () {
-      final illegalThingDescription = {'hello': 'world'};
+    test("should not accept invalid Thing Descriptions", () {
+      final illegalThingDescription = {"hello": "world"};
 
       expect(
         () => ThingDescription.fromJson(illegalThingDescription),
@@ -41,50 +41,50 @@ void main() {
       );
     });
 
-    test('should accept valid Thing Descriptions', () {
+    test("should accept valid Thing Descriptions", () {
       final validThingDescription = {
-        '@context': 'https://www.w3.org/2022/wot/td/v1.1',
-        'title': 'MyLampThing',
-        'security': 'nosec_sc',
-        'securityDefinitions': {
-          'nosec_sc': {'scheme': 'nosec'},
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "title": "MyLampThing",
+        "security": "nosec_sc",
+        "securityDefinitions": {
+          "nosec_sc": {"scheme": "nosec"},
         },
-        'profile': ['https://example.org/test-profile'],
-        'version': {'instance': 'test'},
-        'created': '1970-01-01',
-        'forms': [
+        "profile": ["https://example.org/test-profile"],
+        "version": {"instance": "test"},
+        "created": "1970-01-01",
+        "forms": [
           {
-            'href': 'coaps://example.org',
-            'op': 'readallproperties',
+            "href": "coaps://example.org",
+            "op": "readallproperties",
           }
         ],
       };
 
       final thingDescription = ThingDescription.fromJson(validThingDescription);
 
-      expect(thingDescription.title, 'MyLampThing');
+      expect(thingDescription.title, "MyLampThing");
       expect(
         thingDescription.context,
-        [const (key: null, value: 'https://www.w3.org/2022/wot/td/v1.1')],
+        [const (key: null, value: "https://www.w3.org/2022/wot/td/v1.1")],
       );
-      expect(thingDescription.security, ['nosec_sc']);
-      expect(thingDescription.securityDefinitions['nosec_sc']?.scheme, 'nosec');
+      expect(thingDescription.security, ["nosec_sc"]);
+      expect(thingDescription.securityDefinitions["nosec_sc"]?.scheme, "nosec");
       expect(
         thingDescription.profile,
-        [Uri.tryParse('https://example.org/test-profile')],
+        [Uri.tryParse("https://example.org/test-profile")],
       );
       expect(
         thingDescription.version?.instance,
-        'test',
+        "test",
       );
       expect(
         thingDescription.created,
-        DateTime.tryParse('1970-01-01'),
+        DateTime.tryParse("1970-01-01"),
       );
       final form = thingDescription.forms[0];
       expect(
         form.href,
-        Uri.tryParse('coaps://example.org'),
+        Uri.tryParse("coaps://example.org"),
       );
       expect(
         form.op,
@@ -92,11 +92,11 @@ void main() {
       );
     });
 
-    test('Form', () {
+    test("Form", () {
       final thingDescription = ThingDescription(null);
       final interactionAffordance = Property(thingDescription);
 
-      final uri = Uri.parse('https://example.org');
+      final uri = Uri.parse("https://example.org");
       final form = Form(
         uri,
         interactionAffordance.thingDescription,
@@ -109,18 +109,18 @@ void main() {
         uri,
         interactionAffordance.thingDescription,
         interactionAffordance: interactionAffordance,
-        subprotocol: 'test',
-        scopes: ['test'],
-        response: ExpectedResponse('application/json'),
-        additionalFields: <String, dynamic>{'test': 'test'},
+        subprotocol: "test",
+        scopes: ["test"],
+        response: ExpectedResponse("application/json"),
+        additionalFields: <String, dynamic>{"test": "test"},
       );
 
       expect(form2.href, uri);
-      expect(form2.contentType, 'application/json');
-      expect(form2.subprotocol, 'test');
-      expect(form2.scopes, ['test']);
-      expect(form2.response!.contentType, 'application/json');
-      expect(form2.additionalFields, {'test': 'test'});
+      expect(form2.contentType, "application/json");
+      expect(form2.subprotocol, "test");
+      expect(form2.scopes, ["test"]);
+      expect(form2.response!.contentType, "application/json");
+      expect(form2.additionalFields, {"test": "test"});
 
       final dynamic form3Json = jsonDecode(
         '''
@@ -148,22 +148,22 @@ void main() {
       );
 
       expect(form3.href, uri);
-      expect(form3.contentType, 'application/json');
-      expect(form3.subprotocol, 'test');
+      expect(form3.contentType, "application/json");
+      expect(form3.subprotocol, "test");
       expect(
         form3.op,
         [OperationType.writeproperty, OperationType.readproperty],
       );
-      expect(form3.scopes, ['test1', 'test2']);
-      expect(form3.response?.contentType, 'application/json');
+      expect(form3.scopes, ["test1", "test2"]);
+      expect(form3.response?.contentType, "application/json");
       expect(form3.additionalResponses, [
         AdditionalExpectedResponse(
-          'application/json',
+          "application/json",
           success: false,
-          schema: 'hallo',
+          schema: "hallo",
         ),
       ]);
-      expect(form3.additionalFields, {'test': 'test'});
+      expect(form3.additionalFields, {"test": "test"});
 
       final dynamic form4Json = jsonDecode(
         '''
@@ -181,12 +181,12 @@ void main() {
       );
 
       expect(form4.op, [OperationType.writeproperty]);
-      expect(form4.scopes, ['test']);
+      expect(form4.scopes, ["test"]);
 
       final dynamic form5Json = jsonDecode(
-        '''
+        """
       {
-      }''',
+      }""",
       );
 
       expect(
@@ -226,16 +226,16 @@ void main() {
       final additionalResponse1 = additionalResponses![0];
       final additionalResponse2 = additionalResponses[1];
 
-      expect(additionalResponse1.contentType, 'application/cbor');
-      expect(additionalResponse1.schema, 'hallo');
+      expect(additionalResponse1.contentType, "application/cbor");
+      expect(additionalResponse1.schema, "hallo");
       expect(additionalResponse1.success, false);
 
-      expect(additionalResponse2.contentType, 'text/plain');
+      expect(additionalResponse2.contentType, "text/plain");
       expect(additionalResponse2.schema, null);
 
       expect(
         () => Form(
-          Uri.parse('http://example.org'),
+          Uri.parse("http://example.org"),
           thingDescription,
           interactionAffordance:
               _InvalidInteractionAffordance(thingDescription),
@@ -252,26 +252,26 @@ void main() {
       );
     });
 
-    test('should correctly parse actions', () {
+    test("should correctly parse actions", () {
       final validThingDescription = {
-        '@context': 'https://www.w3.org/2022/wot/td/v1.1',
-        'title': 'MyLampThing',
-        'security': 'nosec_sc',
-        'securityDefinitions': {
-          'nosec_sc': {'scheme': 'nosec'},
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "title": "MyLampThing",
+        "security": "nosec_sc",
+        "securityDefinitions": {
+          "nosec_sc": {"scheme": "nosec"},
         },
-        'actions': {
-          'action': {
-            'safe': true,
-            'idempotent': true,
-            'synchronous': true,
-            'forms': [
-              {'href': 'https://example.org'},
+        "actions": {
+          "action": {
+            "safe": true,
+            "idempotent": true,
+            "synchronous": true,
+            "forms": [
+              {"href": "https://example.org"},
             ],
           },
-          'actionWithDefaults': {
-            'forms': [
-              {'href': 'https://example.org'},
+          "actionWithDefaults": {
+            "forms": [
+              {"href": "https://example.org"},
             ],
           },
         },
@@ -279,89 +279,89 @@ void main() {
 
       final thingDescription = ThingDescription.fromJson(validThingDescription);
 
-      final action = thingDescription.actions['action'];
+      final action = thingDescription.actions["action"];
       expect(action?.safe, true);
       expect(action?.idempotent, true);
       expect(action?.synchronous, true);
 
-      final actionWithDefaults = thingDescription.actions['actionWithDefaults'];
+      final actionWithDefaults = thingDescription.actions["actionWithDefaults"];
       expect(actionWithDefaults?.safe, false);
       expect(actionWithDefaults?.idempotent, false);
       expect(actionWithDefaults?.synchronous, null);
     });
 
-    test('should correctly parse properties', () {
+    test("should correctly parse properties", () {
       final validThingDescription = {
-        '@context': 'https://www.w3.org/2022/wot/td/v1.1',
-        'title': 'MyLampThing',
-        'security': 'nosec_sc',
-        'securityDefinitions': {
-          'nosec_sc': {'scheme': 'nosec'},
-          'auto_sc': {'scheme': 'auto'},
+        "@context": "https://www.w3.org/2022/wot/td/v1.1",
+        "title": "MyLampThing",
+        "security": "nosec_sc",
+        "securityDefinitions": {
+          "nosec_sc": {"scheme": "nosec"},
+          "auto_sc": {"scheme": "auto"},
         },
-        'properties': {
-          'property': {
-            '@type': 'test',
-            'title': 'Test',
-            'titles': {'de': 'German Test', 'en': 'English Test'},
-            'description': 'This is a Test',
-            'descriptions': {
-              'es': 'Esto es una prueba',
-              'en': 'This is a Test',
+        "properties": {
+          "property": {
+            "@type": "test",
+            "title": "Test",
+            "titles": {"de": "German Test", "en": "English Test"},
+            "description": "This is a Test",
+            "descriptions": {
+              "es": "Esto es una prueba",
+              "en": "This is a Test",
             },
-            'writeOnly': true,
-            'readOnly': true,
-            'observable': true,
-            'enum': ['On', 'Off', 3],
-            'constant': 'On',
-            'default': 'On',
-            'unit': 'C',
-            'contentEncoding': 'test',
-            'contentMediaType': 'test',
-            'type': 'string',
-            'forms': [
-              {'href': 'https://example.org'},
+            "writeOnly": true,
+            "readOnly": true,
+            "observable": true,
+            "enum": ["On", "Off", 3],
+            "constant": "On",
+            "default": "On",
+            "unit": "C",
+            "contentEncoding": "test",
+            "contentMediaType": "test",
+            "type": "string",
+            "forms": [
+              {"href": "https://example.org"},
             ],
-            'format': 'test',
-            'pattern': 'test',
-            'items': [
-              {'type': 'integer'},
+            "format": "test",
+            "pattern": "test",
+            "items": [
+              {"type": "integer"},
             ],
-            'minLength': 2,
-            'maxLength': 5,
-            'minItems': 2,
-            'maxItems': 5,
-            'exclusiveMinimum': 3,
-            'exclusiveMaximum': 3,
-            'multipleOf': 1,
-            'minimum': 3,
-            'maximum': 3,
+            "minLength": 2,
+            "maxLength": 5,
+            "minItems": 2,
+            "maxItems": 5,
+            "exclusiveMinimum": 3,
+            "exclusiveMaximum": 3,
+            "multipleOf": 1,
+            "minimum": 3,
+            "maximum": 3,
           },
-          'propertyWithDefaults': {
-            'forms': [
-              {'href': 'https://example.org'},
+          "propertyWithDefaults": {
+            "forms": [
+              {"href": "https://example.org"},
             ],
           },
-          'objectSchemeProperty': {
-            'type': 'object',
-            'properties': {
-              'test': {'type': 'string'},
+          "objectSchemeProperty": {
+            "type": "object",
+            "properties": {
+              "test": {"type": "string"},
             },
-            'required': ['test'],
-            'forms': [
+            "required": ["test"],
+            "forms": [
               {
-                'href': 'https://example.org',
-                'security': 'auto_sc',
+                "href": "https://example.org",
+                "security": "auto_sc",
               }
             ],
           },
-          'propertyWithOneOf': {
-            'oneOf': [
-              {'type': 'string'},
-              {'type': 'integer'},
+          "propertyWithOneOf": {
+            "oneOf": [
+              {"type": "string"},
+              {"type": "integer"},
             ],
-            'forms': [
-              {'href': 'https://example.org'},
+            "forms": [
+              {"href": "https://example.org"},
             ],
           },
         },
@@ -369,29 +369,29 @@ void main() {
 
       final thingDescription = ThingDescription.fromJson(validThingDescription);
 
-      expect(thingDescription.security[0], 'nosec_sc');
-      final noSecurityScheme = thingDescription.securityDefinitions['nosec_sc'];
+      expect(thingDescription.security[0], "nosec_sc");
+      final noSecurityScheme = thingDescription.securityDefinitions["nosec_sc"];
       expect(noSecurityScheme, isA<NoSecurityScheme>());
-      expect(noSecurityScheme?.scheme, 'nosec');
+      expect(noSecurityScheme?.scheme, "nosec");
 
-      final property = thingDescription.properties['property'];
-      expect(property?.atType, ['test']);
-      expect(property?.title, 'Test');
-      expect(property?.description, 'This is a Test');
-      expect(property?.descriptions?['es'], 'Esto es una prueba');
-      expect(property?.descriptions?['en'], 'This is a Test');
+      final property = thingDescription.properties["property"];
+      expect(property?.atType, ["test"]);
+      expect(property?.title, "Test");
+      expect(property?.description, "This is a Test");
+      expect(property?.descriptions?["es"], "Esto es una prueba");
+      expect(property?.descriptions?["en"], "This is a Test");
       expect(property?.writeOnly, true);
       expect(property?.readOnly, true);
       expect(property?.observable, true);
-      expect(property?.enumeration, ['On', 'Off', 3]);
-      expect(property?.constant, 'On');
-      expect(property?.defaultValue, 'On');
-      expect(property?.format, 'test');
-      expect(property?.pattern, 'test');
-      expect(property?.contentEncoding, 'test');
-      expect(property?.contentMediaType, 'test');
-      expect(property?.unit, 'C');
-      expect(property?.items?[0].type, 'integer');
+      expect(property?.enumeration, ["On", "Off", 3]);
+      expect(property?.constant, "On");
+      expect(property?.defaultValue, "On");
+      expect(property?.format, "test");
+      expect(property?.pattern, "test");
+      expect(property?.contentEncoding, "test");
+      expect(property?.contentMediaType, "test");
+      expect(property?.unit, "C");
+      expect(property?.items?[0].type, "integer");
       expect(property?.minLength, 2);
       expect(property?.maxLength, 5);
       expect(property?.minItems, 2);
@@ -403,142 +403,142 @@ void main() {
       expect(property?.multipleOf, 1);
 
       final propertyWithDefaults =
-          thingDescription.properties['propertyWithDefaults'];
+          thingDescription.properties["propertyWithDefaults"];
       expect(propertyWithDefaults?.writeOnly, false);
       expect(propertyWithDefaults?.readOnly, false);
       expect(propertyWithDefaults?.observable, false);
 
       final objectSchemeProperty =
-          thingDescription.properties['objectSchemeProperty'];
-      expect(objectSchemeProperty?.required, ['test']);
-      expect(objectSchemeProperty?.type, 'object');
+          thingDescription.properties["objectSchemeProperty"];
+      expect(objectSchemeProperty?.required, ["test"]);
+      expect(objectSchemeProperty?.type, "object");
 
-      expect(objectSchemeProperty?.forms[0].security, ['auto_sc']);
+      expect(objectSchemeProperty?.forms[0].security, ["auto_sc"]);
       final autoSecurityScheme =
           objectSchemeProperty?.forms[0].securityDefinitions[0];
       expect(autoSecurityScheme, isA<AutoSecurityScheme>());
-      expect(autoSecurityScheme?.scheme, 'auto');
+      expect(autoSecurityScheme?.scheme, "auto");
 
-      final testSchema = objectSchemeProperty?.properties?['test'];
+      final testSchema = objectSchemeProperty?.properties?["test"];
       expect(testSchema, isA<DataSchema>());
-      expect(testSchema?.type, 'string');
+      expect(testSchema?.type, "string");
       final propertyWithOneOf =
-          thingDescription.properties['propertyWithOneOf'];
+          thingDescription.properties["propertyWithOneOf"];
       final stringSchema = propertyWithOneOf?.oneOf?[0];
       final integerSchema = propertyWithOneOf?.oneOf?[1];
 
       expect(stringSchema, isA<DataSchema>());
-      expect(stringSchema?.type, 'string');
+      expect(stringSchema?.type, "string");
       expect(integerSchema, isA<DataSchema>());
-      expect(integerSchema?.type, 'integer');
+      expect(integerSchema?.type, "integer");
     });
   });
 
-  test('Should correctly parse Additional SecuritySchemes', () {
+  test("Should correctly parse Additional SecuritySchemes", () {
     final rawThingDescription = {
-      '@context': [
-        'https://www.w3.org/2022/wot/td/v1.1',
+      "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1",
         {
-          'ace': 'http://www.example.org/ace-security#',
-          'saref': 'https://w3id.org/saref#',
+          "ace": "http://www.example.org/ace-security#",
+          "saref": "https://w3id.org/saref#",
         }
       ],
-      'id': 'urn:uuid:5edfed77-fc4e-46d4-a550-ef7f07592fbd',
-      '@type': ['saref:LightSwitch'],
-      'title': 'NAMIB WoT Thing',
-      'base': 'coap://192.168.71.200',
-      'properties': {
-        'status': {
-          '@type': ['saref:OnOffState'],
-          'title': 'Lamp status',
-          'description': 'The status of the lamp',
-          'forms': [
+      "id": "urn:uuid:5edfed77-fc4e-46d4-a550-ef7f07592fbd",
+      "@type": ["saref:LightSwitch"],
+      "title": "NAMIB WoT Thing",
+      "base": "coap://192.168.71.200",
+      "properties": {
+        "status": {
+          "@type": ["saref:OnOffState"],
+          "title": "Lamp status",
+          "description": "The status of the lamp",
+          "forms": [
             {
-              'op': ['readproperty'],
-              'href': 'led/status',
-              'contentType': 'application/json',
+              "op": ["readproperty"],
+              "href": "led/status",
+              "contentType": "application/json",
             }
           ],
-          'enum': ['On', 'Off'],
-          'readOnly': true,
-          'writeOnly': false,
-          'type': 'string',
+          "enum": ["On", "Off"],
+          "readOnly": true,
+          "writeOnly": false,
+          "type": "string",
         },
       },
-      'actions': {
-        'toggle': {
-          '@type': ['saref:ToggleCommand'],
-          'title': 'Toggle lamp',
-          'description': 'Toggle the status of the lamp',
-          'forms': [
+      "actions": {
+        "toggle": {
+          "@type": ["saref:ToggleCommand"],
+          "title": "Toggle lamp",
+          "description": "Toggle the status of the lamp",
+          "forms": [
             {
-              'op': ['invokeaction'],
-              'href': 'led/toggle',
-              'contentType': 'application/json',
+              "op": ["invokeaction"],
+              "href": "led/toggle",
+              "contentType": "application/json",
             }
           ],
-          'output': {'readOnly': false, 'writeOnly': false, 'type': 'string'},
-          'safe': false,
-          'idempotent': false,
+          "output": {"readOnly": false, "writeOnly": false, "type": "string"},
+          "safe": false,
+          "idempotent": false,
         },
       },
-      'security': ['ace_sc'],
-      'securityDefinitions': {
-        'ace_sc': {
-          'scheme': 'ace:ACESecurityScheme',
-          'ace:as': 'coaps://192.168.42.205:7744/authorize',
-          'ace:audience': 'NAMIB_Demonstrator',
-          'ace:scopes': ['led/status', 'led/toggle', 'temperature/value'],
+      "security": ["ace_sc"],
+      "securityDefinitions": {
+        "ace_sc": {
+          "scheme": "ace:ACESecurityScheme",
+          "ace:as": "coaps://192.168.42.205:7744/authorize",
+          "ace:audience": "NAMIB_Demonstrator",
+          "ace:scopes": ["led/status", "led/toggle", "temperature/value"],
         },
       },
     };
 
     final thingDescription = ThingDescription.fromJson(rawThingDescription);
     expect(
-      thingDescription.securityDefinitions['ace_sc']?.scheme,
-      'ace:ACESecurityScheme',
+      thingDescription.securityDefinitions["ace_sc"]?.scheme,
+      "ace:ACESecurityScheme",
     );
   });
 
-  test('Should only parse allowed Operation Types', () {
+  test("Should only parse allowed Operation Types", () {
     expect(
-      OperationType.fromString('invokeaction'),
+      OperationType.fromString("invokeaction"),
       OperationType.invokeaction,
     );
 
     expect(
-      () => OperationType.fromString('test'),
+      () => OperationType.fromString("test"),
       throwsA(isA<ValidationException>()),
     );
   });
 
-  test('Should correctly parse ExpectedResponse', () {
+  test("Should correctly parse ExpectedResponse", () {
     final firstResponse = ExpectedResponse(
-      'application/json',
-      additionalFields: {'test': 'test'},
+      "application/json",
+      additionalFields: {"test": "test"},
     );
 
-    expect(firstResponse.additionalFields?['test'], 'test');
+    expect(firstResponse.additionalFields?["test"], "test");
 
     final expectedResponseJson = {
-      'contentType': 'application/json',
-      'test': 'test',
+      "contentType": "application/json",
+      "test": "test",
     };
 
     final secondResponse =
         ExpectedResponse.fromJson(expectedResponseJson, PrefixMapping());
 
     expect(secondResponse, isA<ExpectedResponse>());
-    expect(secondResponse.additionalFields?['test'], 'test');
+    expect(secondResponse.additionalFields?["test"], "test");
   });
 
-  test('Should reject invalid @context entries', () {
+  test("Should reject invalid @context entries", () {
     final invalidThingDescription1 = {
-      '@context': 5,
-      'title': 'Test',
-      'security': 'nosec_sc',
-      'securityDefinitions': {
-        'nosec_sc': {'scheme': 'nosec'},
+      "@context": 5,
+      "title": "Test",
+      "security": "nosec_sc",
+      "securityDefinitions": {
+        "nosec_sc": {"scheme": "nosec"},
       },
     };
 
@@ -551,11 +551,11 @@ void main() {
     );
 
     final invalidThingDescription2 = {
-      '@context': ['https://www.w3.org/2022/wot/td/v1.1', 5],
-      'title': 'Test',
-      'security': 'nosec_sc',
-      'securityDefinitions': {
-        'nosec_sc': {'scheme': 'nosec'},
+      "@context": ["https://www.w3.org/2022/wot/td/v1.1", 5],
+      "title": "Test",
+      "security": "nosec_sc",
+      "securityDefinitions": {
+        "nosec_sc": {"scheme": "nosec"},
       },
     };
 
@@ -565,18 +565,18 @@ void main() {
     );
   });
 
-  test('Should reject invalid @context entries', () {
+  test("Should reject invalid @context entries", () {
     // TODO(JKRhb): Double-check if this the correct behavior.
     final invalidThingDescription1 = {
-      '@context': [
-        'https://www.w3.org/2022/wot/td/v1.1',
-        {'invalid': 1},
+      "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1",
+        {"invalid": 1},
       ],
-      'title': 'NAMIB WoT Thing',
-      'security': ['nosec_sc'],
-      'securityDefinitions': {
-        'nosec_sc': {
-          'scheme': 'nosec',
+      "title": "NAMIB WoT Thing",
+      "security": ["nosec_sc"],
+      "securityDefinitions": {
+        "nosec_sc": {
+          "scheme": "nosec",
         },
       },
     };

--- a/test/core/discovery_test.dart
+++ b/test/core/discovery_test.dart
@@ -4,31 +4,31 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:async';
-import 'dart:convert';
+import "dart:async";
+import "dart:convert";
 
-import 'package:dart_wot/src/core/content.dart';
-import 'package:dart_wot/src/core/protocol_interfaces/protocol_client.dart';
-import 'package:dart_wot/src/core/protocol_interfaces/protocol_client_factory.dart';
-import 'package:dart_wot/src/core/servient.dart';
-import 'package:dart_wot/src/core/thing_discovery.dart';
-import 'package:dart_wot/src/definitions/form.dart';
-import 'package:dart_wot/src/scripting_api/subscription.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/src/core/content.dart";
+import "package:dart_wot/src/core/protocol_interfaces/protocol_client.dart";
+import "package:dart_wot/src/core/protocol_interfaces/protocol_client_factory.dart";
+import "package:dart_wot/src/core/servient.dart";
+import "package:dart_wot/src/core/thing_discovery.dart";
+import "package:dart_wot/src/definitions/form.dart";
+import "package:dart_wot/src/scripting_api/subscription.dart";
+import "package:test/test.dart";
 
-const testUriScheme = 'test';
+const testUriScheme = "test";
 final validTestDiscoveryUri =
-    Uri.parse('$testUriScheme://[::1]/.well-known/wot');
+    Uri.parse("$testUriScheme://[::1]/.well-known/wot");
 final invalidTestDiscoveryUri =
-    Uri.parse('$testUriScheme://[::2]/.well-known/wot');
-final directoryTestUri1 = Uri.parse('$testUriScheme://[::3]/.well-known/wot');
-final directoryTestThingsUri1 = Uri.parse('$testUriScheme://[::3]/things');
-final directoryTestUri2 = Uri.parse('$testUriScheme://[::4]/.well-known/wot');
-final directoryTestThingsUri2 = Uri.parse('$testUriScheme://[::4]/things');
-final directoryTestUri3 = Uri.parse('$testUriScheme://[::5]/.well-known/wot');
-final directoryTestThingsUri3 = Uri.parse('$testUriScheme://[::5]/things');
+    Uri.parse("$testUriScheme://[::2]/.well-known/wot");
+final directoryTestUri1 = Uri.parse("$testUriScheme://[::3]/.well-known/wot");
+final directoryTestThingsUri1 = Uri.parse("$testUriScheme://[::3]/things");
+final directoryTestUri2 = Uri.parse("$testUriScheme://[::4]/.well-known/wot");
+final directoryTestThingsUri2 = Uri.parse("$testUriScheme://[::4]/things");
+final directoryTestUri3 = Uri.parse("$testUriScheme://[::5]/.well-known/wot");
+final directoryTestThingsUri3 = Uri.parse("$testUriScheme://[::5]/things");
 
-const validTestTitle1 = 'Test TD 1';
+const validTestTitle1 = "Test TD 1";
 const validTestThingDescription = '''
   {
       "@context": "https://www.w3.org/2022/wot/td/v1.1",
@@ -40,7 +40,7 @@ const validTestThingDescription = '''
   }
 ''';
 
-const validDirectoryTestTitle1 = 'Test TD 2';
+const validDirectoryTestTitle1 = "Test TD 2";
 final directoryThingDescription1 = '''
 {
   "@context": [
@@ -65,7 +65,7 @@ final directoryThingDescription1 = '''
 }
 ''';
 
-const validDirectoryTestTitle2 = 'Test TD 3';
+const validDirectoryTestTitle2 = "Test TD 3";
 final directoryThingDescription2 = '''
 {
   "@context": [
@@ -90,7 +90,7 @@ final directoryThingDescription2 = '''
 }
 ''';
 
-const validDirectoryTestTitle3 = 'Test TD 2';
+const validDirectoryTestTitle3 = "Test TD 2";
 final directoryThingDescription3 = '''
 {
   "@context": [
@@ -137,18 +137,18 @@ class _MockedProtocolClient implements ProtocolClient {
   Future<Content> readResource(Form form) async {
     final href = form.href;
     if (href == directoryTestThingsUri1) {
-      return '[$validTestThingDescription]'.toContent('application/td+json');
+      return "[$validTestThingDescription]".toContent("application/td+json");
     }
 
     if (href == directoryTestThingsUri2) {
-      return '[$invalidTestThingDescription2]'.toContent('application/td+json');
+      return "[$invalidTestThingDescription2]".toContent("application/td+json");
     }
 
     if (href == directoryTestThingsUri3) {
-      return invalidTestThingDescription2.toContent('application/td+json');
+      return invalidTestThingDescription2.toContent("application/td+json");
     }
 
-    throw StateError('Encountered an unknown URI $href.');
+    throw StateError("Encountered an unknown URI $href.");
   }
 
   @override
@@ -173,7 +173,7 @@ class _MockedProtocolClient implements ProtocolClient {
       return directoryThingDescription3.toDiscoveryContent(url);
     }
 
-    throw StateError('Encountered invalid URL.');
+    throw StateError("Encountered invalid URL.");
   }
 
   @override
@@ -237,7 +237,7 @@ extension _DiscoveryContentCreationExtension on String {
   Stream<List<int>> get _body => Stream.fromIterable([utf8.encode(this)]);
 
   DiscoveryContent toDiscoveryContent(Uri url) {
-    return DiscoveryContent('application/td+json', _body, url);
+    return DiscoveryContent("application/td+json", _body, url);
   }
 
   Content toContent(String type) {
@@ -246,8 +246,8 @@ extension _DiscoveryContentCreationExtension on String {
 }
 
 void main() {
-  group('requestThingDescription()', () {
-    test('should be able to retrieve a valid TD', () async {
+  group("requestThingDescription()", () {
+    test("should be able to retrieve a valid TD", () async {
       final servient = Servient(
         clientFactories: [
           _MockedProtocolClientFactory(),
@@ -262,7 +262,7 @@ void main() {
     });
 
     test(
-      'should throw an exception when an invalid TD is retrieved',
+      "should throw an exception when an invalid TD is retrieved",
       () async {
         final servient = Servient(
           clientFactories: [
@@ -280,8 +280,8 @@ void main() {
     );
   });
 
-  group('exploreDirectory()', () {
-    test('should be able to discover valid TDs from a TD directory', () async {
+  group("exploreDirectory()", () {
+    test("should be able to discover valid TDs from a TD directory", () async {
       final servient = Servient(
         clientFactories: [
           _MockedProtocolClientFactory(),
@@ -301,7 +301,7 @@ void main() {
       expect(thingDiscoveryProcess.done, true);
     });
 
-    test('should reject invalid TDD Thing Descriptions', () async {
+    test("should reject invalid TDD Thing Descriptions", () async {
       final servient = Servient(
         clientFactories: [
           _MockedProtocolClientFactory(),
@@ -316,7 +316,7 @@ void main() {
       );
     });
 
-    test('should be able to handle an array of invalid TDs during discovery',
+    test("should be able to handle an array of invalid TDs during discovery",
         () async {
       final servient = Servient(
         clientFactories: [
@@ -349,7 +349,7 @@ void main() {
     });
 
     test(
-        'should be able to handle an invalid non-array output during discovery',
+        "should be able to handle an invalid non-array output during discovery",
         () async {
       final servient = Servient(
         clientFactories: [
@@ -365,7 +365,7 @@ void main() {
       );
     });
 
-    test('should be able to handle premature cancellation', () async {
+    test("should be able to handle premature cancellation", () async {
       final servient = Servient(
         clientFactories: [
           _MockedProtocolClientFactory(),

--- a/test/core/interaction_output_test.dart
+++ b/test/core/interaction_output_test.dart
@@ -4,22 +4,22 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'dart:convert';
+import "dart:convert";
 
-import 'package:dart_wot/src/core/content.dart';
-import 'package:dart_wot/src/core/content_serdes.dart';
-import 'package:dart_wot/src/core/interaction_output.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/src/core/content.dart";
+import "package:dart_wot/src/core/content_serdes.dart";
+import "package:dart_wot/src/core/interaction_output.dart";
+import "package:test/test.dart";
 
 void main() {
-  group('InteractionOutput should', () {
-    test('output the correct value', () async {
-      const inputValue = 'foo';
+  group("InteractionOutput should", () {
+    test("output the correct value", () async {
+      const inputValue = "foo";
       final input = utf8.encode(inputValue);
 
       final contentSerdes = ContentSerdes();
       final content = Content(
-        'text/plain',
+        "text/plain",
         Stream.fromIterable([
           input,
         ]),
@@ -35,13 +35,13 @@ void main() {
       expect(value2, inputValue);
     });
 
-    test('output the same value when calling value() twice', () async {
-      const inputValue = 'bar';
+    test("output the same value when calling value() twice", () async {
+      const inputValue = "bar";
       final input = utf8.encode(inputValue);
 
       final contentSerdes = ContentSerdes();
       final content = Content(
-        'text/plain',
+        "text/plain",
         Stream.fromIterable([
           input,
         ]),

--- a/test/core/servient_test.dart
+++ b/test/core/servient_test.dart
@@ -4,15 +4,15 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dart_wot/dart_wot.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/dart_wot.dart";
+import "package:test/test.dart";
 
-const testUriScheme = 'test';
+const testUriScheme = "test";
 
 class MockedProtocolClientFactory implements ProtocolClientFactory {
   @override
   ProtocolClient createClient() {
-    throw UnimplementedError('Instantiating a client is not supported yet.');
+    throw UnimplementedError("Instantiating a client is not supported yet.");
   }
 
   @override
@@ -30,8 +30,8 @@ class MockedProtocolClientFactory implements ProtocolClientFactory {
 }
 
 void main() {
-  group('Servient Tests', () {
-    test('Should accept a ProtocolClientFactory list as constructor argument',
+  group("Servient Tests", () {
+    test("Should accept a ProtocolClientFactory list as constructor argument",
         () {
       final servient = Servient(
         clientFactories: [
@@ -44,7 +44,7 @@ void main() {
     });
 
     test(
-      'Should allow for adding and removing a ProtocolClientFactory at runtime',
+      "Should allow for adding and removing a ProtocolClientFactory at runtime",
       () {
         final servient = Servient()
           ..addClientFactory(MockedProtocolClientFactory());

--- a/test/scripting_api/data_schema_value_test.dart
+++ b/test/scripting_api/data_schema_value_test.dart
@@ -4,12 +4,12 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dart_wot/scripting_api.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/scripting_api.dart";
+import "package:test/test.dart";
 
 void main() {
-  group('DataSchemaValue', () {
-    test('should use the wrapped value for toString()', () {
+  group("DataSchemaValue", () {
+    test("should use the wrapped value for toString()", () {
       const inputValue = 42;
       final dataSchemaValue = DataSchemaValue.fromNumber(inputValue);
 

--- a/test/scripting_api/interaction_input_test.dart
+++ b/test/scripting_api/interaction_input_test.dart
@@ -4,13 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import 'package:dart_wot/scripting_api.dart';
-import 'package:test/test.dart';
+import "package:dart_wot/scripting_api.dart";
+import "package:test/test.dart";
 
 void main() {
-  group('InteractionInput', () {
-    group('should be able to be instantiated from', () {
-      test('null', () {
+  group("InteractionInput", () {
+    group("should be able to be instantiated from", () {
+      test("null", () {
         final interactionInput = InteractionInput.fromNull();
 
         expect(interactionInput, isA<DataSchemaValueInput>());
@@ -25,8 +25,8 @@ void main() {
         expect(interactionInput.hashCode, alternativeInteractionInput.hashCode);
       });
 
-      test('a String', () {
-        const testValue = 'foo';
+      test("a String", () {
+        const testValue = "foo";
         final interactionInput = InteractionInput.fromString(testValue);
 
         expect(interactionInput, isA<DataSchemaValueInput>());
@@ -46,7 +46,7 @@ void main() {
         expect(interactionInput.hashCode, alternativeInteractionInput.hashCode);
       });
 
-      test('an Integer', () {
+      test("an Integer", () {
         const testValue = 42;
         final interactionInput = InteractionInput.fromInteger(testValue);
 
@@ -67,7 +67,7 @@ void main() {
         expect(interactionInput.hashCode, alternativeInteractionInput.hashCode);
       });
 
-      test('a Number', () {
+      test("a Number", () {
         const testValue = 42.0;
         final interactionInput = InteractionInput.fromNumber(testValue);
 
@@ -88,7 +88,7 @@ void main() {
         expect(interactionInput.hashCode, alternativeInteractionInput.hashCode);
       });
 
-      test('a Boolean', () {
+      test("a Boolean", () {
         const testValue = true;
         final interactionInput = InteractionInput.fromBoolean(testValue);
 
@@ -109,8 +109,8 @@ void main() {
         expect(interactionInput.hashCode, alternativeInteractionInput.hashCode);
       });
 
-      test('an Array', () {
-        const testValue = [true, 42, 'foo'];
+      test("an Array", () {
+        const testValue = [true, 42, "foo"];
         final interactionInput = InteractionInput.fromArray(testValue);
 
         expect(interactionInput, isA<DataSchemaValueInput>());
@@ -135,16 +135,16 @@ void main() {
         expect(interactionInput.hashCode, alternativeInteractionInput.hashCode);
       });
 
-      test('an Object', () {
+      test("an Object", () {
         const testValue = <String, Object?>{
-          'bool': true,
-          'int': 42,
-          'string': 'foo',
-          'number': 42.0,
-          'null': null,
-          'array': [true, 'bar', 42],
-          'object': {
-            'string': 'baz',
+          "bool": true,
+          "int": 42,
+          "string": "foo",
+          "number": 42.0,
+          "null": null,
+          "array": [true, "bar", 42],
+          "object": {
+            "string": "baz",
           },
         };
         final interactionInput = InteractionInput.fromObject(testValue);
@@ -171,7 +171,7 @@ void main() {
         expect(interactionInput.hashCode, alternativeInteractionInput.hashCode);
       });
 
-      test('a byte stream', () {
+      test("a byte stream", () {
         final testValue = Stream.fromIterable([
           [0, 1, 2],
           [3, 4, 5],


### PR DESCRIPTION
After https://github.com/eclipse-thingweb/dart_wot/commit/4900290f2a18616ad70c0b2582637337f24a7597 introduced single-quoted strings, I came to the conclusion that I prefer double-quoted strings for the codebase. This PR reverses the default for the linter and applies the automated fixes to the package.