### PR TITLE
fix: remove temporary TD context URI

### DIFF
--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -26,7 +26,6 @@ import "../version_info.dart";
 const _validTdContextValues = [
   "https://www.w3.org/2019/wot/td/v1",
   "https://www.w3.org/2022/wot/td/v1.1",
-  "http://www.w3.org/ns/td",
 ];
 
 /// Extension for parsing fields of JSON objects.


### PR DESCRIPTION
The temporary TD @context URI `http://www.w3.org/ns/td` is not supported anymore. Therefore, this PR removes it from the list of valid URIs that is used during the (de)serialization process.