### PR TITLE
Add missing copyright headers

### DIFF
--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -1,3 +1,9 @@
+// Copyright 2022 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import "dart:io";
 import "dart:typed_data";
 

--- a/lib/src/binding_http/http_request_method.dart
+++ b/lib/src/binding_http/http_request_method.dart
@@ -1,3 +1,9 @@
+// Copyright 2022 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import "../definitions/form.dart";
 import "../definitions/operation_type.dart";
 

--- a/lib/src/definitions/extensions/json_parser.dart
+++ b/lib/src/definitions/extensions/json_parser.dart
@@ -1,3 +1,9 @@
+// Copyright 2022 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import "package:collection/collection.dart";
 import "package:curie/curie.dart";
 

--- a/lib/src/definitions/version_info.dart
+++ b/lib/src/definitions/version_info.dart
@@ -1,3 +1,9 @@
+// Copyright 2022 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
 import "package:curie/curie.dart";
 
 import "extensions/json_parser.dart";


### PR DESCRIPTION
I noticed that a couple of files are currently missing copyright headers. This PR adds headers with the correct creation year to the respective files.