### PR TITLE
feat!: make credentials classes immutable

### DIFF
--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -74,7 +74,7 @@ const thingDescriptionJson = {
 };
 
 final Map<String, BasicCredentials> basicCredentials = {
-  "urn:test": BasicCredentials("username", "password"),
+  "urn:test": const BasicCredentials("username", "password"),
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -34,7 +34,7 @@ const thingDescriptionJson = {
   },
 };
 
-final basicCredentials = BasicCredentials("username", "password");
+const basicCredentials = BasicCredentials("username", "password");
 
 final Map<String, BasicCredentials> basicCredentialsMap = {
   "urn:test": basicCredentials,

--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -45,7 +45,7 @@ const thingDescriptionJson = {
 };
 
 final Map<String, BasicCredentials> basicCredentials = {
-  "urn:test": BasicCredentials("rw", "readwrite"),
+  "urn:test": const BasicCredentials("rw", "readwrite"),
 };
 
 Future<BasicCredentials?> basicCredentialsCallback(

--- a/lib/src/core/credentials/ace_credentials.dart
+++ b/lib/src/core/credentials/ace_credentials.dart
@@ -12,7 +12,7 @@ import "credentials.dart";
 /// [Credentials] used for the [AceSecurityScheme].
 final class AceCredentials extends Credentials {
   /// Constructor.
-  AceCredentials(this.accessToken);
+  const AceCredentials(this.accessToken);
 
   /// The access token associated with these [AceCredentials] in serialized
   /// form.

--- a/lib/src/core/credentials/apikey_credentials.dart
+++ b/lib/src/core/credentials/apikey_credentials.dart
@@ -11,8 +11,8 @@ import "credentials.dart";
 /// [Credentials] used for the [ApiKeySecurityScheme].
 final class ApiKeyCredentials extends Credentials {
   /// Constructor.
-  ApiKeyCredentials(this.apiKey);
+  const ApiKeyCredentials(this.apiKey);
 
   /// The [apiKey] associated with these [ApiKeyCredentials].
-  String apiKey;
+  final String apiKey;
 }

--- a/lib/src/core/credentials/basic_credentials.dart
+++ b/lib/src/core/credentials/basic_credentials.dart
@@ -13,11 +13,11 @@ import "credentials.dart";
 /// Provides an unencrypted [username] and [password] combination.
 final class BasicCredentials extends Credentials {
   /// Constructor.
-  BasicCredentials(this.username, this.password);
+  const BasicCredentials(this.username, this.password);
 
   /// The [username] associated with these [BasicCredentials].
-  String username;
+  final String username;
 
   /// The [password] associated with these [BasicCredentials].
-  String password;
+  final String password;
 }

--- a/lib/src/core/credentials/bearer_credentials.dart
+++ b/lib/src/core/credentials/bearer_credentials.dart
@@ -11,8 +11,8 @@ import "credentials.dart";
 /// [Credentials] used for the [BearerSecurityScheme].
 final class BearerCredentials extends Credentials {
   /// Constructor.
-  BearerCredentials(this.token);
+  const BearerCredentials(this.token);
 
   /// The [token] associated with these [BearerCredentials].
-  String token;
+  final String token;
 }

--- a/lib/src/core/credentials/credentials.dart
+++ b/lib/src/core/credentials/credentials.dart
@@ -4,5 +4,11 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import "package:meta/meta.dart";
+
 /// Base class used for defining credentials for Thing Interactions.
-abstract base class Credentials {}
+@immutable
+abstract base class Credentials {
+  /// Default constructor for credentials objects.
+  const Credentials();
+}

--- a/lib/src/core/credentials/digest_credentials.dart
+++ b/lib/src/core/credentials/digest_credentials.dart
@@ -10,11 +10,11 @@ import "credentials.dart";
 /// [Credentials] used for the [DigestSecurityScheme].
 final class DigestCredentials extends Credentials {
   /// Constructor.
-  DigestCredentials(this.username, this.password);
+  const DigestCredentials(this.username, this.password);
 
   /// The [username] associated with these [DigestCredentials].
-  String username;
+  final String username;
 
   /// The [password] associated with these [DigestCredentials].
-  String password;
+  final String password;
 }

--- a/lib/src/core/credentials/oauth2_credentials.dart
+++ b/lib/src/core/credentials/oauth2_credentials.dart
@@ -10,13 +10,16 @@ import "credentials.dart";
 /// [Credentials] used for the [OAuth2SecurityScheme].
 final class OAuth2Credentials extends Credentials {
   /// Constructor.
-  OAuth2Credentials([this.secret]);
+  const OAuth2Credentials({
+    this.secret,
+    this.credentialsJson,
+  });
 
   /// The optional secret for these [OAuth2Credentials].
-  String? secret;
+  final String? secret;
 
   /// A JSON string representation of OAuth2 credentials.
   ///
   /// Used to store obtained credentials from an authorization server.
-  String? credentialsJson;
+  final String? credentialsJson;
 }

--- a/lib/src/core/credentials/psk_credentials.dart
+++ b/lib/src/core/credentials/psk_credentials.dart
@@ -12,7 +12,7 @@ import "credentials.dart";
 /// [Credentials] used for the [PskSecurityScheme].
 final class PskCredentials extends Credentials {
   /// Constructor.
-  PskCredentials({required this.preSharedKey, required this.identity});
+  const PskCredentials({required this.preSharedKey, required this.identity});
 
   /// The [identity] associated with these [PskCredentials].
   ///

--- a/test/binding_http/http_test.dart
+++ b/test/binding_http/http_test.dart
@@ -93,11 +93,11 @@ void main() {
         final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
 
         final Map<String, BasicCredentials> basicCredentialsStore = {
-          "httpbin.org": BasicCredentials(username, password),
+          "httpbin.org": const BasicCredentials(username, password),
         };
 
         final Map<String, BearerCredentials> bearerCredentialsStore = {
-          "httpbin.org": BearerCredentials(token),
+          "httpbin.org": const BearerCredentials(token),
         };
 
         Future<BasicCredentials?> basicCredentialsCallback(


### PR DESCRIPTION
This PR applies the `@immutable` annotation to the `Credentials` base class and makes the necessary adjustments in the inheriting classes regarding immutability to make the library more reliable and slightly increase its performance.