### PR TITLE
feat!: add initial support for query parameters to exploreDirectory method

### DIFF
--- a/example/directory_discovery.dart
+++ b/example/directory_discovery.dart
@@ -1,0 +1,29 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+// ignore_for_file: avoid_print
+
+import "package:dart_wot/binding_http.dart";
+import "package:dart_wot/core.dart";
+
+Future<void> main(List<String> args) async {
+  final servient = Servient(
+    clientFactories: [
+      HttpClientFactory(),
+    ],
+  );
+
+  final wot = await servient.start();
+  // FIXME(JRKhb): The "things" property currently points to "localhost",
+  //               preventing this example from working
+  final url = Uri.parse("https://zion.vaimee.com/.well-known/wot");
+
+  final thingDiscovery = await wot.exploreDirectory(url);
+
+  await for (final thingDescription in thingDiscovery) {
+    print(thingDescription);
+  }
+}

--- a/lib/src/core/implementation/wot.dart
+++ b/lib/src/core/implementation/wot.dart
@@ -111,9 +111,17 @@ class WoT implements scripting_api.WoT {
 
   @override
   Future<scripting_api.ThingDiscoveryProcess> exploreDirectory(
-    Uri url, [
+    Uri url, {
     scripting_api.ThingFilter? filter,
-  ]) async {
+    int? offset,
+    int? limit,
+    scripting_api.DirectoryPayloadFormat? format,
+  }) async {
+    // TODO(JKRhb): Add support for the collection format.
+    if (format == scripting_api.DirectoryPayloadFormat.collection) {
+      throw ArgumentError('Format "$format" is currently not supported.');
+    }
+
     final thingDescription = await requestThingDescription(url);
 
     if (!thingDescription.isValidDirectoryThingDescription) {
@@ -124,8 +132,14 @@ class WoT implements scripting_api.WoT {
 
     final consumedDirectoryThing = await consume(thingDescription);
 
-    final interactionOutput =
-        await consumedDirectoryThing.readProperty("things");
+    final interactionOutput = await consumedDirectoryThing.readProperty(
+      "things",
+      uriVariables: {
+        if (offset != null) "offset": offset,
+        if (limit != null) "limit": limit,
+        if (format != null) "format": format.toString(),
+      },
+    );
     final rawThingDescriptions = await interactionOutput.value();
 
     if (rawThingDescriptions is! List<Object?>) {

--- a/lib/src/core/scripting_api/wot.dart
+++ b/lib/src/core/scripting_api/wot.dart
@@ -13,6 +13,35 @@ import "discovery/thing_filter.dart";
 import "exposed_thing.dart";
 import "types.dart";
 
+/// Enumeration for specifying the value of the `format` query parameter when
+/// using the `exploreDirectory` discovery method.
+///
+/// See [section 7.3.2.1.5] of the [WoT Discovery] specification for more
+/// information.
+///
+/// [WoT Discovery]: https://www.w3.org/TR/2023/REC-wot-discovery-20231205
+/// [section 7.3.2.1.5]: https://www.w3.org/TR/2023/REC-wot-discovery-20231205/#exploration-directory-api-things-listing
+enum DirectoryPayloadFormat {
+  /// Indicates that an array of Thing Descriptions should be returned.
+  ///
+  /// This is the default value.
+  array,
+
+  /// Indicates that an collection of Thing Descriptions should be returned.
+  collection,
+  ;
+
+  @override
+  String toString() {
+    switch (this) {
+      case array:
+        return "array";
+      case collection:
+        return "collection";
+    }
+  }
+}
+
 /// Interface for a [WoT] runtime.
 ///
 /// See WoT Scripting API specification,
@@ -39,9 +68,12 @@ abstract interface class WoT {
   /// [ThingDescription] objects for Thing Descriptions that match an optional
   /// [filter] argument of type [ThingFilter].
   Future<ThingDiscoveryProcess> exploreDirectory(
-    Uri url, [
+    Uri url, {
     ThingFilter? filter,
-  ]);
+    int? offset,
+    int? limit,
+    DirectoryPayloadFormat? format,
+  });
 
   /// Discovers [ThingDescription]s from a given [url] using the specified
   /// [method].


### PR DESCRIPTION
As currently discussed in https://github.com/w3c/wot-scripting-api/issues/528, this PR adds initial experimental support for the three query parameters `offset`, `limit`, and `format` to the `exploreDirectory` method.

At the moment only the `format` value `array` is supported, with the value `collection` left open for a follow-up PR. While implementing, however, I noticed that the current approach does not allow for an elegant passing of the `next` links (from the HTTP response headers) to the upper layers of the library.

Not only in the context of `dart_wot` but also for `node-wot` we could therefore discuss expanding the `Content` class/interface to be able to pass this information alongside the payload data. However, there is probably some discussion needed to do this in a protocol-agnostic manner.