### PR TITLE
fix: fix handling of uri variables

### DIFF
--- a/lib/src/core/implementation/augmented_form.dart
+++ b/lib/src/core/implementation/augmented_form.dart
@@ -145,29 +145,20 @@ final class AugmentedForm implements Form {
           "level: ${uncoveredHrefUriVariables.join(", ")}.");
     }
 
-    final missingTdLevelUserInput = uriVariablesInHref.where(
-      (uriVariableName) =>
-          !userProvidedUriVariables.containsKey(uriVariableName),
-    );
-
-    if (missingTdLevelUserInput.isNotEmpty) {
-      throw UriVariableException(
-        "The following URI template variables defined at the TD level are not "
-        "covered by the values provided by the user: "
-        "${missingTdLevelUserInput.join(", ")}. "
-        "Values for the following variables were received: "
-        "${userProvidedUriVariables.keys.join(", ")}.",
-      );
-    }
-
     // We now assert that all user provided values comply to the Schema
     // definition in the TD.
     for (final affordanceUriVariable in affordanceUriVariables.entries) {
       final key = affordanceUriVariable.key;
-      final value = affordanceUriVariable.value;
 
-      final schema = JsonSchema.create(value);
-      final result = schema.validate(userProvidedUriVariables[key]);
+      final userProvidedValue = userProvidedUriVariables[key];
+
+      if (userProvidedValue == null) {
+        continue;
+      }
+
+      final schemaValue = affordanceUriVariable.value;
+      final schema = JsonSchema.create(schemaValue);
+      final result = schema.validate(userProvidedValue);
 
       if (!result.isValid) {
         throw ValidationException("Invalid type for URI variable $key");

--- a/test/core/augmented_form_test.dart
+++ b/test/core/augmented_form_test.dart
@@ -164,8 +164,8 @@ void main() {
       );
 
       expect(
-        () => augmentedForm2.resolvedHref,
-        throwsA(isA<UriVariableException>()),
+        augmentedForm2.resolvedHref,
+        Uri.parse("http://example.org/weather/?lat=5"),
       );
 
       final augmentedForm3 = AugmentedForm(
@@ -178,18 +178,8 @@ void main() {
       );
 
       expect(
-        () => augmentedForm3.resolvedHref,
-        throwsA(
-          predicate(
-            (exception) =>
-                exception is UriVariableException &&
-                exception.toString() ==
-                    "UriVariableException: The following URI template "
-                        "variables defined at the TD level are not covered by "
-                        "the values provided by the user: lat. Values for the "
-                        "following variables were received: long.",
-          ),
-        ),
+        augmentedForm3.resolvedHref,
+        Uri.parse("http://example.org/weather/?long=10"),
       );
 
       final augmentedForm4 = AugmentedForm(


### PR DESCRIPTION
The logic for validating URI variables has been a bit too strict, preventing all interactions when a value for a URI variable was not provided by the user, for example in the case of the experimental extension of the `exploreDirectory` discovery method in #94.

As also already briefly discussed in https://github.com/w3c/wot-scripting-api/issues/528, the handling of URI variables needs to be improved in general, so this topic should be revisited in future PRs.