### PR TITLE
feat!: add supportsOperation method

### DIFF
--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -34,6 +34,7 @@ const thingDescriptionJson = {
         {
           "href": "coap://californium.eclipseprojects.io/obs",
           "op": ["observeproperty", "unobserveproperty"],
+          "subprotocol": "cov:observe",
         }
       ],
     },

--- a/lib/src/binding_coap/coap_client_factory.dart
+++ b/lib/src/binding_coap/coap_client_factory.dart
@@ -8,6 +8,7 @@ import "../../core.dart";
 
 import "coap_client.dart";
 import "coap_config.dart";
+import "coap_definitions.dart";
 
 /// A [ProtocolClientFactory] that produces CoAP clients.
 final class CoapClientFactory implements ProtocolClientFactory {
@@ -44,5 +45,22 @@ final class CoapClientFactory implements ProtocolClientFactory {
   @override
   bool init() {
     return true;
+  }
+
+  @override
+  bool supportsOperation(OperationType operationType, String? subprotocol) {
+    const observeOperations = [
+      OperationType.observeproperty,
+      OperationType.unobserveproperty,
+      OperationType.subscribeevent,
+      OperationType.unsubscribeevent,
+    ];
+
+    if (observeOperations.contains(operationType)) {
+      return CoapSubprotocol.tryParse(subprotocol ?? "") ==
+          CoapSubprotocol.observe;
+    }
+
+    return subprotocol == null;
   }
 }

--- a/lib/src/binding_http/http_client_factory.dart
+++ b/lib/src/binding_http/http_client_factory.dart
@@ -42,4 +42,24 @@ final class HttpClientFactory implements ProtocolClientFactory {
   bool init() {
     return true;
   }
+
+  @override
+  bool supportsOperation(OperationType operationType, String? subprotocol) {
+    const unsupportedOperations = [
+      OperationType.observeproperty,
+      OperationType.unobserveproperty,
+      OperationType.subscribeevent,
+      OperationType.unsubscribeevent,
+    ];
+
+    if (unsupportedOperations.contains(operationType)) {
+      return false;
+    }
+
+    if (subprotocol != null) {
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/lib/src/binding_mqtt/mqtt_client_factory.dart
+++ b/lib/src/binding_mqtt/mqtt_client_factory.dart
@@ -42,4 +42,10 @@ final class MqttClientFactory implements ProtocolClientFactory {
 
   @override
   Set<String> get schemes => {mqttUriScheme, mqttSecureUriScheme};
+
+  @override
+  bool supportsOperation(OperationType operationType, String? subprotocol) {
+    // MQTT client does not support any subprotocols
+    return subprotocol == null;
+  }
 }

--- a/lib/src/core/implementation/consumed_thing.dart
+++ b/lib/src/core/implementation/consumed_thing.dart
@@ -97,9 +97,19 @@ class ConsumedThing implements scripting_api.ConsumedThing {
       }
     } else {
       foundForm = augmentedForms.firstWhere(
-        (form) =>
-            hasClientFor(form.href.scheme) &&
-            _supportsOperationType(form, interactionAffordance, operationType),
+        (form) {
+          final opValues = form.op;
+
+          if (!opValues.contains(operationType)) {
+            return false;
+          }
+
+          return servient.supportsOperation(
+            form.resolvedHref.scheme,
+            operationType,
+            form.subprotocol,
+          );
+        },
         // TODO(JKRhb): Add custom Exception
         orElse: () => throw Exception("No matching form found!"),
       );
@@ -427,17 +437,6 @@ class ConsumedThing implements scripting_api.ConsumedThing {
       case scripting_api.SubscriptionType.event:
         _subscribedEvents.remove(key);
     }
-  }
-
-  static bool _supportsOperationType(
-    Form form,
-    InteractionAffordance interactionAffordance,
-    OperationType operationType,
-  ) {
-    final opValues =
-        form.op ?? OperationType.defaultOpValues(interactionAffordance);
-
-    return opValues.contains(operationType);
   }
 
   /// Cleans up the resources used by this [ConsumedThing].

--- a/lib/src/core/implementation/protocol_interfaces/protocol_client_factory.dart
+++ b/lib/src/core/implementation/protocol_interfaces/protocol_client_factory.dart
@@ -4,6 +4,9 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import "package:meta/meta.dart";
+
+import "../../definitions.dart";
 import "protocol_client.dart";
 
 /// Base class for a factory that produces [ProtocolClient]s.
@@ -24,4 +27,9 @@ abstract interface class ProtocolClientFactory {
   /// Creates a new [ProtocolClient] with that supports one or more of the given
   /// [schemes].
   ProtocolClient createClient();
+
+  /// Indicates whether this [ProtocolClientFactory] supports a given
+  /// [operationType] and subprotocol.
+  @experimental
+  bool supportsOperation(OperationType operationType, String? subprotocol);
 }

--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import "package:meta/meta.dart";
+
 import "../definitions.dart";
 import "../scripting_api.dart" as scripting_api;
 import "consumed_thing.dart";
@@ -220,6 +222,26 @@ class Servient {
     }
 
     return clientFactory.createClient();
+  }
+
+  /// Indicates whether there is a registered [ProtocolClientFactory] supporting
+  /// the given [operationType] and [subprotocol].
+  ///
+  /// Also returns `false` if there is no [ProtocolClientFactory] registered for
+  /// the given [scheme].
+  @experimental
+  bool supportsOperation(
+    String scheme,
+    OperationType operationType,
+    String? subprotocol,
+  ) {
+    final protocolClient = _clientFactories[scheme];
+
+    if (protocolClient == null) {
+      return false;
+    }
+
+    return protocolClient.supportsOperation(operationType, subprotocol);
   }
 
   /// Requests a [ThingDescription] from a [url].

--- a/test/binding_coap/coap_client_factory_test.dart
+++ b/test/binding_coap/coap_client_factory_test.dart
@@ -1,0 +1,66 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/binding_coap.dart";
+import "package:dart_wot/core.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("CoapClientFactory should", () {
+    test("indicate correctly whether an operation is supported", () {
+      final coapClientFactory = CoapClientFactory();
+
+      const observeOperations = [
+        OperationType.observeproperty,
+        OperationType.unobserveproperty,
+        OperationType.subscribeevent,
+        OperationType.unsubscribeevent,
+      ];
+      final otherOperations = OperationType.values
+          .where((operationType) => !observeOperations.contains(operationType));
+
+      final testVector = [
+        (
+          expectedResult: true,
+          operationTypes: observeOperations,
+          subprotocol: "cov:observe",
+        ),
+        (
+          expectedResult: false,
+          operationTypes: observeOperations,
+          subprotocol: null,
+        ),
+        (
+          expectedResult: true,
+          operationTypes: otherOperations,
+          subprotocol: null,
+        ),
+        (
+          expectedResult: false,
+          operationTypes: otherOperations,
+          subprotocol: "cov:observe",
+        ),
+        (
+          expectedResult: false,
+          operationTypes: OperationType.values,
+          subprotocol: "foobar",
+        ),
+      ];
+
+      for (final testCase in testVector) {
+        for (final operationType in testCase.operationTypes) {
+          expect(
+            coapClientFactory.supportsOperation(
+              operationType,
+              testCase.subprotocol,
+            ),
+            testCase.expectedResult,
+          );
+        }
+      }
+    });
+  });
+}

--- a/test/binding_http/http_client_factory_test.dart
+++ b/test/binding_http/http_client_factory_test.dart
@@ -1,0 +1,61 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/binding_http.dart";
+import "package:dart_wot/core.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("HttpClientFactory should", () {
+    test("indicate correctly whether an operation is supported", () {
+      final httpClientFactory = HttpClientFactory();
+
+      const observeOperations = [
+        OperationType.observeproperty,
+        OperationType.unobserveproperty,
+        OperationType.subscribeevent,
+        OperationType.unsubscribeevent,
+      ];
+      final otherOperations = OperationType.values
+          .where((operationType) => !observeOperations.contains(operationType));
+
+      final testVector = [
+        (
+          expectedResult: false,
+          operationTypes: observeOperations,
+          subprotocol: null,
+        ),
+        (
+          expectedResult: false,
+          operationTypes: observeOperations,
+          subprotocol: "foobar",
+        ),
+        (
+          expectedResult: true,
+          operationTypes: otherOperations,
+          subprotocol: null,
+        ),
+        (
+          expectedResult: false,
+          operationTypes: otherOperations,
+          subprotocol: "foobar",
+        ),
+      ];
+
+      for (final testCase in testVector) {
+        for (final operationType in testCase.operationTypes) {
+          expect(
+            httpClientFactory.supportsOperation(
+              operationType,
+              testCase.subprotocol,
+            ),
+            testCase.expectedResult,
+          );
+        }
+      }
+    });
+  });
+}

--- a/test/binding_mqtt/mqtt_client_factory_test.dart
+++ b/test/binding_mqtt/mqtt_client_factory_test.dart
@@ -1,0 +1,42 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/binding_mqtt.dart";
+import "package:dart_wot/core.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("MqttClientFactory should", () {
+    test("indicate correctly whether an operation is supported", () {
+      final coapClientFactory = MqttClientFactory();
+
+      final testVector = [
+        (
+          expectedResult: false,
+          operationTypes: OperationType.values,
+          subprotocol: "foobar",
+        ),
+        (
+          expectedResult: true,
+          operationTypes: OperationType.values,
+          subprotocol: null,
+        ),
+      ];
+
+      for (final testCase in testVector) {
+        for (final operationType in testCase.operationTypes) {
+          expect(
+            coapClientFactory.supportsOperation(
+              operationType,
+              testCase.subprotocol,
+            ),
+            testCase.expectedResult,
+          );
+        }
+      }
+    });
+  });
+}

--- a/test/core/discovery_test.dart
+++ b/test/core/discovery_test.dart
@@ -258,6 +258,10 @@ class _MockedProtocolClientFactory implements ProtocolClientFactory {
 
   @override
   Set<String> get schemes => {testUriScheme};
+
+  @override
+  bool supportsOperation(OperationType operationType, String? subprotocol) =>
+      true;
 }
 
 extension _DiscoveryContentCreationExtension on String {

--- a/test/core/servient_test.dart
+++ b/test/core/servient_test.dart
@@ -27,6 +27,10 @@ class MockedProtocolClientFactory implements ProtocolClientFactory {
 
   @override
   Set<String> get schemes => {testUriScheme};
+
+  @override
+  bool supportsOperation(OperationType operationType, String? subprotocol) =>
+      true;
 }
 
 void main() {


### PR DESCRIPTION
This PR adds new methods called `supportsOperation` to the codebase, which are used to indicate whether a protocol's clients support a given combination of `OperationType` and `subprotocol`.

This solves an issue I've experienced when trying to interact with things that support both CoAP and HTTP for observing properties or subscribing to events, as the long-polling subprotocol is not implemented for dart_wot's HTTP client yet. Therefore, the client could throw an exception since the filtering mechanism was not sufficient enough for the `Servient` to simply ignore those unsupported forms.

The newly added methods should this problem for now. However, as more parameters might need to be added to the respective methods, I've labeled the methods as `@experimental` for now in order to indicate that they should be handled with caution.