### PR TITLE
feat(binding_coap): add tryParse method to CoapSubprotocol

### DIFF
--- a/lib/src/binding_coap/coap_definitions.dart
+++ b/lib/src/binding_coap/coap_definitions.dart
@@ -55,4 +55,15 @@ enum CoapRequestMethod {
 enum CoapSubprotocol {
   /// Subprotocol for observing CoAP resources.
   observe,
+  ;
+
+  /// Tries to match the given [subprotocol] string to one of the known
+  /// [CoapSubprotocol.values].
+  static CoapSubprotocol? tryParse(String subprotocol) {
+    if (subprotocol == "cov:observe") {
+      return CoapSubprotocol.observe;
+    }
+
+    return null;
+  }
 }

--- a/test/binding_coap/coap_definitions_test.dart
+++ b/test/binding_coap/coap_definitions_test.dart
@@ -11,8 +11,8 @@ import "package:dart_wot/src/binding_coap/coap_extensions.dart";
 import "package:test/test.dart";
 
 void main() {
-  group("CoAP definitions", () {
-    test("should deserialize CoAP Forms", () async {
+  group("CoAP definitions should", () {
+    test("deserialize CoAP Forms", () async {
       const thingDescriptionJson = {
         "@context": [
           "https://www.w3.org/2022/wot/td/v1.1",
@@ -87,5 +87,13 @@ void main() {
         throwsA(isA<ValidationException>()),
       );
     });
+  });
+
+  test("parse CoAP subprotocols", () async {
+    final observeSubprotocol = CoapSubprotocol.tryParse("cov:observe");
+    expect(observeSubprotocol == CoapSubprotocol.observe, isTrue);
+
+    final unknownSubprotocol = CoapSubprotocol.tryParse("foobar");
+    expect(unknownSubprotocol, isNull);
   });
 }


### PR DESCRIPTION
This PR adds a static method named `tryParse` to the `CoapSubprotocol` enhanced enum that makes it possible to generate enum values from strings if the string value is known. Otherwise, the method returns `null`.