### PR TITLE
chore!(servient): remove `hasClientFor` method

### DIFF
--- a/lib/src/core/implementation/consumed_thing.dart
+++ b/lib/src/core/implementation/consumed_thing.dart
@@ -59,10 +59,6 @@ class ConsumedThing implements scripting_api.ConsumedThing {
   /// Determines the id of this [ConsumedThing].
   String get identifier => thingDescription.identifier;
 
-  /// Checks if the [Servient] of this [ConsumedThing] supports a protocol
-  /// [scheme].
-  bool hasClientFor(String scheme) => servient.hasClientFor(scheme);
-
   (ProtocolClient client, AugmentedForm form) _getClientFor(
     List<Form> forms,
     OperationType operationType,

--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -208,9 +208,6 @@ class Servient {
   ProtocolClientFactory? removeClientFactory(String scheme) =>
       _clientFactories.remove(scheme);
 
-  /// Checks whether a [ProtocolClient] is avaiable for a given [scheme].
-  bool hasClientFor(String scheme) => _clientFactories.containsKey(scheme);
-
   /// Returns the [ProtocolClient] associated with a given [scheme].
   ProtocolClient clientFor(String scheme) {
     final clientFactory = _clientFactories[scheme];

--- a/test/core/servient_test.dart
+++ b/test/core/servient_test.dart
@@ -44,7 +44,6 @@ void main() {
       );
 
       expect(servient.clientSchemes, [testUriScheme]);
-      expect(servient.hasClientFor(testUriScheme), true);
     });
 
     test(
@@ -53,11 +52,11 @@ void main() {
         final servient = Servient()
           ..addClientFactory(MockedProtocolClientFactory());
 
-        expect(servient.hasClientFor(testUriScheme), true);
+        expect(servient.clientSchemes.contains(testUriScheme), true);
 
         servient.removeClientFactory(testUriScheme);
 
-        expect(servient.hasClientFor(testUriScheme), false);
+        expect(servient.clientSchemes.contains(testUriScheme), false);
         expect(servient.clientSchemes.length, 0);
       },
     );


### PR DESCRIPTION
This PR removes the `hasClientFor` method from the `Servient` class and other classes that depend on it. In the context of #96, I noticed that this method is not really needed. Therefore, this PR cleans up the codebase a bit by relying on the `clientSchemes` getter instead.