### PR TITLE
refactor(thing_discovery): refactor _clientForUriScheme

### DIFF
--- a/lib/src/core/implementation/thing_discovery.dart
+++ b/lib/src/core/implementation/thing_discovery.dart
@@ -71,14 +71,15 @@ class ThingDiscovery extends Stream<ThingDescription>
 
   ProtocolClient _clientForUriScheme(Uri uri) {
     final uriScheme = uri.scheme;
-    var client = _clients[uriScheme];
+    final existingClient = _clients[uriScheme];
 
-    if (client == null) {
-      client = _servient.clientFor(uriScheme);
-      _clients[uriScheme] = client;
+    if (existingClient != null) {
+      return existingClient;
     }
 
-    return client;
+    final newClient = _servient.clientFor(uriScheme);
+    _clients[uriScheme] = newClient;
+    return newClient;
   }
 
   @override


### PR DESCRIPTION
This PR includes a rather trivial refactoring of the `ThingDiscovery` implementation's `_clientForUriScheme` method, replacing the unneeded `var` with an immutable `final` keyword.