### PR TITLE
chore: adjust main example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,17 @@ Future<void> main(List<String> args) async {
     '"${thingDescription.title}"!',
   );
 
+  print(consumedThing.thingDescription.events);
+  final subscription = await consumedThing.subscribeEvent("change", print);
+
   print("Incrementing counter ...");
   await consumedThing.invokeAction("increment");
 
   final status = await consumedThing.readProperty("count");
   final value = await status.value();
   print("New counter value: $value");
+
+  await subscription.stop();
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Below you can find a basic example for incrementing and reading the value of a
 counter Thing, which is part of the
 [Thingweb Online Things](https://www.thingweb.io/services).
 
-In the example, we first create a WoT runtime using a `Servient` with CoAP
-support.
+In the example, we first create a WoT runtime using a `Servient` with CoAP and
+HTTP support.
 With the runtime, we then retrieve a TD (using the `requestThingDescription()`
 method) and consume it (using the `consume()` method), creating a
 `ConsumedThing` object,
@@ -56,12 +56,14 @@ Afterward, the actual interactions with the counter are performed by calling the
 
 ```dart
 import "package:dart_wot/binding_coap.dart";
+import "package:dart_wot/binding_http.dart";
 import "package:dart_wot/core.dart";
 
 Future<void> main(List<String> args) async {
   final servient = Servient(
     clientFactories: [
       CoapClientFactory(),
+      HttpClientFactory(),
     ],
   );
   final wot = await servient.start();

--- a/example/example.dart
+++ b/example/example.dart
@@ -7,12 +7,14 @@
 // ignore_for_file: avoid_print
 
 import "package:dart_wot/binding_coap.dart";
+import "package:dart_wot/binding_http.dart";
 import "package:dart_wot/core.dart";
 
 Future<void> main(List<String> args) async {
   final servient = Servient(
     clientFactories: [
       CoapClientFactory(),
+      HttpClientFactory(),
     ],
   );
   final wot = await servient.start();

--- a/example/example.dart
+++ b/example/example.dart
@@ -29,10 +29,15 @@ Future<void> main(List<String> args) async {
     '"${thingDescription.title}"!',
   );
 
+  print(consumedThing.thingDescription.events);
+  final subscription = await consumedThing.subscribeEvent("change", print);
+
   print("Incrementing counter ...");
   await consumedThing.invokeAction("increment");
 
   final status = await consumedThing.readProperty("count");
   final value = await status.value();
   print("New counter value: $value");
+
+  await subscription.stop();
 }


### PR DESCRIPTION
This PR adds some changes to the main example to reflect the latest changes to the codebase in terms of form selection and the explicit support for the `cov:observe` subprotocol. For this PR to work, some upstream changes in node-wot are needed which are hopefully going to be merged soon. Until then, this PR will be put on hold. 