### PR TITLE
fix(servient): use WoT interface as start() return type

### DIFF
--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -68,9 +68,9 @@ class Servient {
 
   /// Starts this [Servient] and returns a [WoT] runtime object.
   ///
-  /// The [WoT] runtime can be used for consuming, procuding, and discovering
-  /// Things.
-  Future<WoT> start() async {
+  /// The [scripting_api.WoT] runtime can be used for consuming, procuding, and
+  /// discovering Things.
+  Future<scripting_api.WoT> start() async {
     final serverStatuses = _servers
         .map((server) => server.start(_serverSecurityCallback))
         .toList(growable: false);


### PR DESCRIPTION
This PR fixes an oversight in the return type of the `Servient`'s `start()` method, which did not return the Scripting API subpackage's `WoT` _interface_ but the `WoT` _implementation_. When merged, this PR resolves the issue, creating a cleaner API surface.