### PR TITLE
fix(servient): check the correct map during addConsumedThing

### DIFF
--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -162,7 +162,7 @@ class Servient {
   /// `true`.
   bool addConsumedThing(ConsumedThing thing) {
     final id = thing.identifier;
-    if (_things.containsKey(id)) {
+    if (_consumedThings.containsKey(id)) {
       return false;
     }
 


### PR DESCRIPTION
When using the `WoT` interface's `consume` method, you are not supposed to be able to consume the same Thing Description twice (although this is probably debatable). Due to an oversight (checking the wrong internal `Map`), this behavior has not been enforced so far, which is corrected by this PR.