### PR TITLE
feat!: make custom exceptions immutable

### DIFF
--- a/lib/src/core/definitions/extensions/json_parser.dart
+++ b/lib/src/core/definitions/extensions/json_parser.dart
@@ -290,7 +290,7 @@ extension ParseField on Map<String, dynamic> {
       return forms;
     }
 
-    throw ValidationException(
+    throw const ValidationException(
       'Missing "forms" member in Intraction Affordance',
     );
   }

--- a/lib/src/core/exceptions.dart
+++ b/lib/src/core/exceptions.dart
@@ -4,18 +4,21 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import "package:meta/meta.dart";
+
 export "exceptions/web_idl.dart";
 
 /// Base class for custom exceptions defined in `dart_wot`.
+@immutable
 base class DartWotException implements Exception {
   /// Constructor.
-  DartWotException(this.message);
+  const DartWotException(this.message);
 
   /// The error message of this [ValidationException].
   final String message;
 
   /// The name of this [Exception] that will appear in the error message log.
-  final exceptionType = "DartWotException";
+  String get exceptionType => "DartWotException";
 
   @override
   String toString() => "$exceptionType: $message";
@@ -24,7 +27,7 @@ base class DartWotException implements Exception {
 /// An [Exception] that is thrown when the validation of a definition fails.
 base class ValidationException extends DartWotException {
   /// Constructor.
-  ValidationException(super.message, [this._validationErrors]);
+  const ValidationException(super.message, [this._validationErrors]);
 
   final List<Object>? _validationErrors;
 
@@ -52,7 +55,7 @@ base class ValidationException extends DartWotException {
 /// Custom [Exception] that is thrown when the discovery process fails.
 final class DiscoveryException extends DartWotException {
   /// Creates a new [DiscoveryException] with the specified error [message].
-  DiscoveryException(super.message);
+  const DiscoveryException(super.message);
 
   @override
   String get exceptionType => "DiscoveryException";

--- a/lib/src/core/exceptions/web_idl.dart
+++ b/lib/src/core/exceptions/web_idl.dart
@@ -13,7 +13,7 @@ import "../exceptions.dart";
 /// [NotReadableError]: https://webidl.spec.whatwg.org/#notreadableerror
 final class NotReadableException extends DartWotException {
   /// Instantiates a new [NotReadableException] with the given [message].
-  NotReadableException(super.message);
+  const NotReadableException(super.message);
 
   @override
   String get exceptionType => "NotReadableException";

--- a/lib/src/core/implementation/content_serdes.dart
+++ b/lib/src/core/implementation/content_serdes.dart
@@ -145,7 +145,7 @@ class ContentSerdes {
     }
 
     if (dataSchemaValue == null) {
-      throw ValidationException("Expected a defined dataSchemaValue");
+      throw const ValidationException("Expected a defined dataSchemaValue");
     }
 
     final schema = JsonSchema.create(
@@ -153,7 +153,7 @@ class ContentSerdes {
       schemaVersion: SchemaVersion.draft7,
     );
     if (!schema.validate(dataSchemaValue.value).isValid) {
-      throw ValidationException("JSON Schema validation failed.");
+      throw const ValidationException("JSON Schema validation failed.");
     }
   }
 

--- a/lib/src/core/implementation/interaction_output.dart
+++ b/lib/src/core/implementation/interaction_output.dart
@@ -47,7 +47,7 @@ class InteractionOutput implements scripting_api.InteractionOutput {
   @override
   Future<ByteBuffer> arrayBuffer() async {
     if (dataUsed) {
-      throw NotReadableException("Data has already been read");
+      throw const NotReadableException("Data has already been read");
     }
 
     _dataUsed = true;
@@ -65,7 +65,7 @@ class InteractionOutput implements scripting_api.InteractionOutput {
     }
 
     if (schema == null) {
-      throw NotReadableException(
+      throw const NotReadableException(
         "Can't convert data to a value because no DataSchema is present.",
       );
     }

--- a/lib/src/core/implementation/wot.dart
+++ b/lib/src/core/implementation/wot.dart
@@ -95,7 +95,7 @@ class WoT implements scripting_api.WoT {
     final thingDescription = await requestThingDescription(url);
 
     if (!thingDescription.isValidDirectoryThingDescription) {
-      throw DiscoveryException(
+      throw const DiscoveryException(
         "Encountered an invalid Directory Thing Description",
       );
     }
@@ -113,7 +113,7 @@ class WoT implements scripting_api.WoT {
     final rawThingDescriptions = await interactionOutput.value();
 
     if (rawThingDescriptions is! List<Object?>) {
-      throw DiscoveryException(
+      throw const DiscoveryException(
         "Expected an array of Thing Descriptions but received an "
         "invalid output instead.",
       );

--- a/test/core/exceptions_test.dart
+++ b/test/core/exceptions_test.dart
@@ -11,27 +11,27 @@ void main() {
   group("DartWotException should", () {
     test("be indicate the respective name in its toString() method", () {
       expect(
-        DartWotException("test").toString(),
+        const DartWotException("test").toString(),
         "DartWotException: test",
       );
 
       expect(
-        ValidationException("test").toString(),
+        const ValidationException("test").toString(),
         "ValidationException: test",
       );
 
       expect(
-        ValidationException("test", ["test", "test"]).toString(),
+        const ValidationException("test", ["test", "test"]).toString(),
         "ValidationException: test\n\nErrors:\n\ntest\ntest",
       );
 
       expect(
-        DiscoveryException("test").toString(),
+        const DiscoveryException("test").toString(),
         "DiscoveryException: test",
       );
 
       expect(
-        NotReadableException("test").toString(),
+        const NotReadableException("test").toString(),
         "NotReadableException: test",
       );
     });


### PR DESCRIPTION
This PR applies the `immutable` annotation to the `DartWotException` base class for custom exceptions, while applying the `const` modifier for custom exceptions where possible.