### PR TITLE
chore(CHANGELOG.md): use correct link to initial release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -536,5 +536,5 @@ JSON-LD.
 [0.3.0]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.1.0...v0.1.1
-[0.1.0]: https://github.com/olivierlacan/keep-a-changelog/releases/tag/v0.1.0
+[0.1.0]: https://github.com/eclipse-thingweb/dart_wot/releases/tag/v0.1.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Switched to the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format for new changelog entries ([#115](https://github.com/eclipse-thingweb/dart_wot/pull/115))
 - Adjusted the main example to also use HTTP and CoAP observe ([#101](https://github.com/eclipse-thingweb/dart_wot/pull/101))
+- Adjusted the link to the initial release in the changelog ([#119](https://github.com/eclipse-thingweb/dart_wot/pull/119))
 
 ### Deprecated
 


### PR DESCRIPTION
While adding git tags that were missing to have actually working links from the CHANGELOG.md file, I noticed that the link to the initial release was pointing to the wrong repository. This PR fixes the issue.

(The filling of the git tag gaps will make it possible to finally switch to the [automated release procedure](https://dart.dev/tools/pub/automated-publishing), that is going to be added via #118.)

As suggested in the last committer meeting (CC @relu91), I took a look into automatically generating changelogs via the conventional-changelog CLI and realized that this is probably the best way forward. I will probably make a new release shortly with the current approach that will fix the links in the changelog on pub.dev, but then switch to the conventional changelog afterward.