### PR TITLE
ci: use Dart 3.3.0 for Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,14 +10,27 @@ on:
 
 jobs:
   build:
+    name: build (${{ matrix.os }})
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
+        # TODO: Remove once https://github.com/dart-lang/sdk/issues/55745
+        #       has been resolved
+        sdk: [stable, 3.3.0]
+        exclude:
+          - os: macos-latest
+            sdk: 3.3.0
+          - os: ubuntu-latest
+            sdk: 3.3.0
+          - os: windows-latest
+            sdk: stable
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
On Windows, the CI currently gets stuck when using the latest version (3.4.0) of the Dart SDK. This PR adds a temporary workaround, using version 3.3.0 on Windows instead. Once https://github.com/dart-lang/sdk/issues/55745 has been resolved, this change should be reverted.