### PR TITLE
chore: prepare release 0.28.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,23 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Added
+## [0.28.1] - 2024-05-17
 
 ### Changed
 
 - Switched to the [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format for new changelog entries ([#115](https://github.com/eclipse-thingweb/dart_wot/pull/115))
 - Adjusted the main example to also use HTTP and CoAP observe ([#101](https://github.com/eclipse-thingweb/dart_wot/pull/101))
 - Adjusted the link to the initial release in the changelog ([#119](https://github.com/eclipse-thingweb/dart_wot/pull/119))
-
-### Deprecated
-
-### Removed
-
-### Fixed
-
-### Security
 
 ## [0.28.0] - 2024-04-28
 
@@ -494,7 +484,7 @@ JSON-LD.
 
 - Initial version.
 
-[Unreleased]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.28.0...HEAD
+[0.28.1]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.28.0...v0.28.1
 [0.28.0]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.27.1...v0.28.0
 [0.27.1]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.27.0...v0.27.1
 [0.27.0]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.26.0...v0.27.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_wot
 description: A W3C Web of Things implementation written in Dart. Supports interacting with Things using CoAP, HTTP, and MQTT.
-version: 0.28.0
+version: 0.28.1
 homepage: https://github.com/eclipse-thingweb/dart_wot
 
 environment:


### PR DESCRIPTION
This PR prepares the release of a new patch release. This will be the first release to use the Keep a Changelog format, and hopefully the last release to use a manual style of changelog generation. In any case, the project's changelog should now be in a much better shape than it was before :)