### PR TITLE
chore(release): prepare release 0.28.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.28.3] - 2024-05-17
 
 ### Added
 
@@ -920,7 +920,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Remove TODO from misc issue template ([f0281cf](https://github.com/eclipse-thingweb/dart_wot/commit/f0281cf91d3ab717fa18aef0576ddef5aaf9abcb))
 
-[Unreleased]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.28.2..HEAD
+[0.28.3]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.28.2..v0.28.3
 [0.28.2]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.28.1..v0.28.2
 [0.28.1]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.28.0..v0.28.1
 [0.28.0]: https://github.com/eclipse-thingweb/dart_wot/compare/v0.27.1..v0.28.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dart_wot
 description: A W3C Web of Things implementation written in Dart. Supports interacting with Things using CoAP, HTTP, and MQTT.
-version: 0.28.2
+version: 0.28.3
 homepage: https://github.com/eclipse-thingweb/dart_wot
 
 environment:


### PR DESCRIPTION
This creates a new release using the new workflow introduced in #120.

While creating this PR, I realized that the transition has turned out a bit more rocky than expected. However, I think from here on, it should be possible to make the process a lot cleaner and easier to handle than before. Furthermore, as noted by @egekorkan, it might be possible to also adapt this workflow to other Thingweb repositories as well.

As a next step, I will improve the documentation of the process and perform a general alignment with the other Thingweb repos.