### PR TITLE
ci: prevent accidental merge of fixup! commits

### DIFF
--- a/.github/workflows/prevent-fixup.yaml
+++ b/.github/workflows/prevent-fixup.yaml
@@ -1,0 +1,21 @@
+name: Prevent Fixup Commits
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  prevent-fixup-commits:
+    name: Check for fixup! commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: 0
+      - name: Check for fixup! commits
+        run: |
+          if git log origin/main..HEAD | grep -q -e '^    fixup!'; then
+            echo "Error: fixup! commits are present in this PR, please remove them before merging."
+            exit 1
+          fi


### PR DESCRIPTION
To prevent the merge of `fixup!` commits in the future, this PR adds a simple GitHub Actions workflow that exists with an error if there should be any commits on the branch whose message starts with `fixup!`. The solution is not that ideal yet, but might get improved at a later point in time.