### PR TITLE
Improve contribution guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to Eclipse Thingweb
+
+Thanks for your interest in this project. General information
+regarding source code management, builds, coding standards, and
+more can be found here:
+
+-   https://projects.eclipse.org/projects/iot.thingweb/developer
+
+## Legal Requirements
+
+Thingweb is an [Eclipse IoT](https://iot.eclipse.org) project and as such is governed by the Eclipse Development process.
+This process helps us in creating great open source software within a safe legal framework.
+
+Thus, before your contribution can be accepted by the project team, contributors must electronically sign the [Eclipse Contributor Agreement (ECA)](http://www.eclipse.org/legal/ECA.php) and follow these preliminary steps:
+
+-   Obtain an [Eclipse Foundation account](https://accounts.eclipse.org/)
+    -   Anyone who currently uses Eclipse Bugzilla or Gerrit systems already has one of those
+    -   Newcomers can [create a new account](https://accounts.eclipse.org/user/register?destination=user)
+-   Add your GiHub username to your Eclipse Foundation account
+    -   ([Log into Eclipse](https://accounts.eclipse.org/))
+    -   Go to the _Edit Profile_ tab
+    -   Fill in the _GitHub ID_ under _Social Media Links_ and save
+-   Sign the [Eclipse Contributor Agreement](http://www.eclipse.org/legal/ECA.php)
+    -   ([Log into Eclipse](https://accounts.eclipse.org/))
+    -   If the _Status_ entry _Eclipse Contributor Agreement_ has a green checkmark, the ECA is already signed
+    -   If not, go to the _Eclipse Contributor Agreement_ tab or follow the corresponding link under _Status_
+    -   Fill out the form and sign it electronically
+-   Sign-off every commit using the same email address used for your Eclipse account
+    -   Set the Git user email address with `git config user.email "<your Eclipse account email>"`
+    -   Add the `-s` flag when you make the commit(s), e.g. `git commit -s -m "feat: add support for magic"`
+-   Open a [Pull Request](https://github.com/eclipse-thingweb/node-wot/pulls)
+
+For more information, please see the Eclipse Committer Handbook:
+https://www.eclipse.org/projects/handbook/#resources-commit
+
+## Contact
+
+Contact the project developers via the project's "dev" list.
+
+-   https://dev.eclipse.org/mailman/listinfo/thingweb-dev

--- a/README.md
+++ b/README.md
@@ -94,21 +94,6 @@ Future<void> main(List<String> args) async {
 
 More complex examples can be found in the `example` directory.
 
-## Additional information
-
-The package will be extended gradually over the upcoming months.
-Support for exposing Things will be added as well as
-more protocols and security schemes.
-
-Contributions are very welcome.
-You will soon be able to find guidelines for contributing to the package
-in a `CONTRIBUTING` file.
-Until then, you can already file issues for pointing out bugs or requesting
-features.
-You can also open PRs; these have to adhere the defined coding style and
-linter rules.
-Contributions will be licensed according to the project licenses (see below).
-
 ## License
 
 `dart_wot` is licensed under the 3-Clause BSD License.

--- a/README.md
+++ b/README.md
@@ -124,9 +124,7 @@ implementation for the Node.js ecosystem.
 
 ## Contribution
 
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in the work by you, shall be licensed as above, without any additional
-terms or conditions.
+Please refer to our [contribution guidelines](CONTRIBUTING.md) for more details.
 
 ## Maintainers
 


### PR DESCRIPTION
This PR expands the contribution guidelines for the repository and aligns them with the other Thingweb repos. It also removes old, obsolete information from the `README` file.

For now, I just copied over parts of the guidelines from node-wot and will add more project-specific information in subsequent PRs. I hope this fine, @danielpeintner, @relu91, and @egekorkan, otherwise please let me know :)