### PR TITLE
chore: update deprecated import from lint package

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,6 +1,6 @@
 # This file configures the analyzer to use the lint rule set from `package:lint`
 
-include: package:lint/analysis_options_package.yaml
+include: package:lint/package.yaml
 
 # Adjusted linting rules
 linter:


### PR DESCRIPTION
The API of the `lint` package that is used for static analysis has changed some time ago. This PR updates the import that is being used accordingly.