### PR TITLE
chore(cliff.toml): bump 0.x.x versions differently

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -90,3 +90,7 @@ ignore_tags = ""
 topo_order = false
 # sort the commits inside sections by oldest/newest order
 sort_commits = "oldest"
+
+[bump]
+features_always_bump_minor = false
+breaking_always_bump_major = false


### PR DESCRIPTION
So far, when using `git cliff` to bump versions, features and breaking changes were handled for 0.x.x versions the same way as for higher major versions numbers. This PR changes the config to bump the version in a more restrained way in order not to accidentally bump the version to 1.0.0.