### PR TITLE
Rework TD @context handling

### DIFF
--- a/lib/src/core/definitions/context.dart
+++ b/lib/src/core/definitions/context.dart
@@ -1,0 +1,213 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:collection/collection.dart";
+import "package:curie/curie.dart";
+import "package:meta/meta.dart";
+
+import "../exceptions.dart";
+
+const _tdVersion10ContextUrl = "https://www.w3.org/2019/wot/td/v1";
+const _tdVersion11ContextUrl = "https://www.w3.org/2022/wot/td/v1.1";
+
+/// Represents the JSON-LD `@context` of a Thing Description or Thing Model.
+@immutable
+final class Context {
+  /// Creates a new context from a list of [contextEntries].
+  Context(this.contextEntries)
+      : prefixMapping = _createPrefixMappping(contextEntries);
+
+  /// Determines the default prefix URL via the procedure described in
+  /// [section 5.3.1.1] of the Thing Description 1.1 specification.
+  ///
+  /// [section 5.3.1.1]: https://www.w3.org/TR/wot-thing-description11/#thing
+  static String _determineDefaultPrefix(
+    List<ContextEntry> contextEntries,
+  ) {
+    final firstContextEntry = contextEntries.firstOrNull;
+
+    if (firstContextEntry is! SingleContextEntry) {
+      throw const ValidationException("Missing TD context URL.");
+    }
+
+    final firstContextValue = firstContextEntry.value;
+
+    if (![_tdVersion10ContextUrl, _tdVersion11ContextUrl]
+        .contains(firstContextValue)) {
+      throw ValidationException(
+        "Encountered invalid TD context URL $firstContextEntry",
+      );
+    }
+
+    final String? secondContextValue;
+
+    final secondContextEntry = contextEntries.elementAtOrNull(1);
+    if (secondContextEntry is SingleContextEntry) {
+      secondContextValue = secondContextEntry.value;
+    } else {
+      secondContextValue = null;
+    }
+
+    if (firstContextValue == _tdVersion10ContextUrl &&
+        secondContextValue == _tdVersion11ContextUrl) {
+      return _tdVersion11ContextUrl;
+    }
+
+    return firstContextValue;
+  }
+
+  static PrefixMapping _createPrefixMappping(
+    List<ContextEntry> contextEntries,
+  ) {
+    final defaultPrefixValue = _determineDefaultPrefix(contextEntries);
+    final prefixMapping = PrefixMapping(defaultPrefixValue: defaultPrefixValue);
+
+    contextEntries
+        .whereType<UriMapContextEntry>()
+        .where((contextEntry) => !contextEntry.key.startsWith("@"))
+        .forEach(
+          (contextEntry) =>
+              prefixMapping.addPrefix(contextEntry.key, contextEntry.value),
+        );
+
+    return prefixMapping;
+  }
+
+  /// List of [ContextEntry] elements in this `@context` definition.
+  ///
+  /// These elements can either be [SingleContextEntry]s (that contain a single
+  /// URI value) or [MapContextEntry]s (that contain key-value pairs).
+  final List<ContextEntry> contextEntries;
+
+  /// Used to map context extension prefixes within the `@context` to URIs.
+  final PrefixMapping prefixMapping;
+
+  /// Allows for directly accessing this [Context]'s [contextEntries] by
+  /// [index].
+  ContextEntry operator [](int index) {
+    return contextEntries[index];
+  }
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! Context) {
+      return false;
+    }
+
+    for (final contextEntryPair
+        in IterableZip([contextEntries, other.contextEntries])) {
+      if (contextEntryPair[0] != contextEntryPair[1]) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  @override
+  int get hashCode => Object.hashAll(contextEntries);
+}
+
+/// Base class for `@context` entries.
+@immutable
+sealed class ContextEntry {
+  const ContextEntry();
+
+  /// The key of this `@context` entry.
+  ///
+  /// Not defined for entries that are not part of a map, i.e. the
+  /// [SingleContextEntry] class.
+  String? get key;
+
+  /// The value of this `@context` entry.
+  String get value;
+}
+
+/// Represents a `@context` entry that contains a [uri] as its [value] and has
+/// no [key] defined.
+final class SingleContextEntry extends ContextEntry {
+  /// Creates a new [SingleContextEntry] from a [uri].
+  const SingleContextEntry(this.uri);
+
+  /// Creates a new [SingleContextEntry] from a [string] that represents a URI.
+  ///
+  /// If the [string] should not be a valid URI, this factory constructor will
+  /// throw a [ValidationException].
+  factory SingleContextEntry.fromString(String string) {
+    final parsedUri = Uri.tryParse(string);
+
+    if (parsedUri == null) {
+      throw ValidationException("Encountered invalid URI $string");
+    }
+
+    return SingleContextEntry(parsedUri);
+  }
+
+  @override
+  String? get key => null;
+
+  /// The [value] of this `@context` entry as a [Uri] object.
+  final Uri uri;
+
+  /// The [String] representation of this `@context` entry's value.
+  @override
+  String get value => uri.toString();
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! SingleContextEntry) {
+      return false;
+    }
+
+    return value == other.value;
+  }
+
+  @override
+  int get hashCode => value.hashCode;
+}
+
+/// Super class of `@context` entries that are [key]-[value] pairs.
+sealed class MapContextEntry extends ContextEntry {
+  const MapContextEntry(this.key);
+
+  /// The key of this `@context` entry.
+  @override
+  final String key;
+
+  @override
+  bool operator ==(Object other) {
+    if (other is! MapContextEntry) {
+      return false;
+    }
+
+    return key == other.key && value == other.value;
+  }
+
+  @override
+  int get hashCode => Object.hash(key, value);
+}
+
+/// Key-value `@context` entry that contains a [uri] as its [value].
+final class UriMapContextEntry extends MapContextEntry {
+  /// Creates a new [UriMapContextEntry] from a [key] and a [uri].
+  const UriMapContextEntry(super.key, this.uri);
+
+  /// The URI that the [key] of this `@context` entry points to.
+  final Uri uri;
+
+  @override
+  String get value => uri.toString();
+}
+
+/// Key-value `@context` entry that contains a non-URI string as its [value].
+final class StringMapContextEntry extends MapContextEntry {
+  /// Creates a new [UriMapContextEntry] from a [key] and a plain string
+  /// [value].
+  const StringMapContextEntry(super.key, this.value);
+
+  @override
+  final String value;
+}

--- a/lib/src/core/definitions/thing_description.dart
+++ b/lib/src/core/definitions/thing_description.dart
@@ -9,6 +9,7 @@ import "package:meta/meta.dart";
 
 import "../exceptions.dart";
 import "additional_expected_response.dart";
+import "context.dart";
 import "data_schema.dart";
 import "extensions/json_parser.dart";
 import "form.dart";
@@ -18,9 +19,6 @@ import "security/security_scheme.dart";
 import "thing_model.dart";
 import "validation/thing_description_schema.dart";
 import "version_info.dart";
-
-/// Type definition for a JSON-LD @context entry.
-typedef ContextEntry = ({String? key, String value});
 
 /// Represents a WoT Thing Description
 @immutable
@@ -51,7 +49,6 @@ class ThingDescription {
     this.description,
     this.version,
     this.uriVariables,
-    this.prefixMapping,
   }) : _rawThingDescription = rawThingDescription;
 
   /// Creates a [ThingDescription] from a [json] object.
@@ -71,9 +68,10 @@ class ThingDescription {
     }
 
     final Set<String> parsedFields = {};
-    final prefixMapping = PrefixMapping();
 
-    final context = json.parseContext(prefixMapping, parsedFields);
+    final context = json.parseContext(parsedFields);
+    final prefixMapping = context.prefixMapping;
+
     final atType = json.parseArrayField<String>("@type", parsedFields);
     final title = json.parseRequiredField<String>("title", parsedFields);
     final titles = json.parseMapField<String>("titles", parsedFields);
@@ -113,7 +111,6 @@ class ThingDescription {
         json.parseAdditionalFields(prefixMapping, parsedFields);
 
     return ThingDescription._(
-      prefixMapping: prefixMapping,
       context: context,
       title: title,
       titles: titles,
@@ -154,10 +151,10 @@ class ThingDescription {
   final Map<String, dynamic> _rawThingDescription;
 
   /// Contains the values of the @context for CURIE expansion.
-  final PrefixMapping? prefixMapping;
+  PrefixMapping get prefixMapping => context.prefixMapping;
 
   /// The JSON-LD `@context`, represented by a  [List] of [ContextEntry]s.
-  final List<ContextEntry> context;
+  final Context context;
 
   /// JSON-LD keyword to label the object with semantic tags (or types).
   final List<String>? atType;

--- a/lib/src/core/implementation/wot.dart
+++ b/lib/src/core/implementation/wot.dart
@@ -9,6 +9,7 @@ import "dart:async";
 import "package:uuid/uuid.dart";
 
 import "../definitions.dart";
+import "../definitions/context.dart";
 import "../exceptions.dart";
 import "../scripting_api.dart" as scripting_api;
 import "consumed_thing.dart";
@@ -143,7 +144,8 @@ extension _DirectoryValidationExtension on ThingDescription {
       return true;
     }
 
-    return context.contains((value: discoveryContextUri, key: null)) &&
+    return context.contextEntries
+            .contains(SingleContextEntry.fromString(discoveryContextUri)) &&
         atTypes.contains(type);
   }
 }

--- a/test/core/context_test.dart
+++ b/test/core/context_test.dart
@@ -1,0 +1,131 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:dart_wot/core.dart";
+import "package:dart_wot/src/core/definitions/context.dart";
+import "package:dart_wot/src/core/definitions/extensions/json_parser.dart";
+import "package:test/test.dart";
+
+void main() {
+  group("Thing Description @context should", () {
+    test("not allow for an invalid first entry", () {
+      final illegalSingleContextEntry =
+          SingleContextEntry.fromString("https://example.com");
+
+      expect(
+        () => Context([illegalSingleContextEntry]),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+
+    test("be supported when including both the TD 1.0 and 1.1 URL", () {
+      const tdVersion11ContextUrl = "https://www.w3.org/2022/wot/td/v1.1";
+
+      final tdVersion10ContextEntry =
+          SingleContextEntry.fromString("https://www.w3.org/2019/wot/td/v1");
+
+      final tdVersion11ContextEntry =
+          SingleContextEntry.fromString(tdVersion11ContextUrl);
+
+      expect(
+        Context([tdVersion10ContextEntry, tdVersion11ContextEntry])
+            .prefixMapping
+            .defaultPrefixValue,
+        tdVersion11ContextUrl,
+      );
+    });
+
+    test("support the inclusion of non-URI map entries", () {
+      final contextJson = {
+        "@context": [
+          "https://www.w3.org/2022/wot/td/v1.1",
+          {
+            "@language": "en",
+          }
+        ],
+      };
+
+      final parsedContext = contextJson.parseContext({});
+
+      expect(
+        Context([
+          SingleContextEntry.fromString("https://www.w3.org/2022/wot/td/v1.1"),
+          const StringMapContextEntry("@language", "en"),
+        ]),
+        parsedContext,
+      );
+    });
+
+    test("correctly override the hashCode getter", () {
+      final contextEntry1 =
+          SingleContextEntry.fromString("https://www.w3.org/2022/wot/td/v1.1");
+      final contextEntry2 =
+          SingleContextEntry.fromString("https://www.w3.org/2022/wot/td/v1.1");
+
+      final context1 = Context([contextEntry1]);
+      final context2 = Context([contextEntry2]);
+
+      expect(context1.hashCode, context2.hashCode);
+    });
+  });
+
+  group("SingleContextEntry should", () {
+    test("only be valid when created from a valid URI", () {
+      expect(
+        () => SingleContextEntry.fromString("::foobar::"),
+        throwsA(isA<ValidationException>()),
+      );
+    });
+
+    test("correctly override the hashCode getter", () {
+      const string1 = "foobar";
+      const string2 = "foobar";
+
+      final singleContextValue1 = SingleContextEntry.fromString(string1);
+      final singleContextValue2 = SingleContextEntry.fromString(string2);
+
+      expect(string1.hashCode, string2.hashCode);
+
+      expect(singleContextValue1.hashCode, singleContextValue2.hashCode);
+    });
+  });
+
+  group("UriMapContextEntry should", () {
+    test("correctly override the == operator", () {
+      final uriMapContextValue1 = UriMapContextEntry("foo", Uri.parse("bar"));
+      final uriMapContextValue2 = UriMapContextEntry("foo", Uri.parse("bar"));
+
+      expect(
+        uriMapContextValue1 == uriMapContextValue2,
+        isTrue,
+      );
+
+      final singleContextValue = SingleContextEntry.fromString("foo");
+
+      expect(
+        // ignore: unrelated_type_equality_checks
+        uriMapContextValue1 == singleContextValue,
+        isFalse,
+      );
+    });
+
+    test("correctly override the hashCode getter", () {
+      const key1 = "foo";
+      const key2 = "foo";
+
+      final value1 = Uri.parse("bar");
+      final value2 = Uri.parse("bar");
+
+      final uriMapContextValue1 = UriMapContextEntry(key1, value1);
+      final uriMapContextValue2 = UriMapContextEntry(key2, value2);
+
+      expect(key1.hashCode, key2.hashCode);
+      expect(value1.hashCode, value2.hashCode);
+
+      expect(uriMapContextValue1.hashCode, uriMapContextValue2.hashCode);
+    });
+  });
+}

--- a/test/core/definitions_test.dart
+++ b/test/core/definitions_test.dart
@@ -8,6 +8,7 @@ import "dart:convert";
 
 import "package:curie/curie.dart";
 import "package:dart_wot/core.dart";
+import "package:dart_wot/src/core/definitions/context.dart";
 import "package:dart_wot/src/core/definitions/extensions/json_parser.dart";
 import "package:test/test.dart";
 
@@ -50,7 +51,13 @@ void main() {
       expect(thingDescription.title, "MyLampThing");
       expect(
         thingDescription.context,
-        [const (key: null, value: "https://www.w3.org/2022/wot/td/v1.1")],
+        Context(
+          [
+            SingleContextEntry.fromString(
+              "https://www.w3.org/2022/wot/td/v1.1",
+            ),
+          ],
+        ),
       );
       expect(thingDescription.security, ["nosec_sc"]);
       expect(thingDescription.securityDefinitions["nosec_sc"]?.scheme, "nosec");

--- a/test/core/thing_description_test.dart
+++ b/test/core/thing_description_test.dart
@@ -57,4 +57,22 @@ void main() {
       throwsA(isA<ValidationException>()),
     );
   });
+
+  test("use the correct @context entry as the default prefix value", () {
+    final thingDescription = {
+      "@context": [
+        "https://www.w3.org/2022/wot/td/v1.1",
+      ],
+      "title": "Invalid TD with missing security field.",
+      "security": "nosec_sc",
+      "securityDefinitions": {
+        "nosec_sc": {"scheme": "nosec"},
+      },
+    }.toThingDescription();
+
+    expect(
+      thingDescription.prefixMapping.defaultPrefixValue,
+      "https://www.w3.org/2022/wot/td/v1.1",
+    );
+  });
 }


### PR DESCRIPTION
This PR improves the deserialization of the TD `@context`, and lays the groundwork for better enhancing the Thing Description objects and their components with context-provided information.

The new structure introduced here is probably an improvement to the one that existed before, however, further restructuring might be applied in the future, especially when it comes to using newer language features.