### PR TITLE
feat(thing_description.dart): add basic toJson implementation

### DIFF
--- a/lib/src/core/definitions/thing_description.dart
+++ b/lib/src/core/definitions/thing_description.dart
@@ -31,6 +31,7 @@ class ThingDescription {
     required this.title,
     required this.security,
     required this.securityDefinitions,
+    required Map<String, dynamic> rawThingDescription,
     this.titles,
     this.atType,
     this.id,
@@ -51,7 +52,7 @@ class ThingDescription {
     this.version,
     this.uriVariables,
     this.prefixMapping,
-  });
+  }) : _rawThingDescription = rawThingDescription;
 
   /// Creates a [ThingDescription] from a [json] object.
 
@@ -136,6 +137,7 @@ class ThingDescription {
       security: security,
       securityDefinitions: securityDefinitions,
       atType: atType,
+      rawThingDescription: json,
     );
   }
 
@@ -146,9 +148,10 @@ class ThingDescription {
   }
 
   /// Converts this [ThingDescription] to a [Map] resembling a JSON objct.
-  Map<String, dynamic> toJson() {
-    throw UnimplementedError();
-  }
+  // TODO: Revisit this for dynamic serialization
+  Map<String, dynamic> toJson() => _rawThingDescription;
+
+  final Map<String, dynamic> _rawThingDescription;
 
   /// Contains the values of the @context for CURIE expansion.
   final PrefixMapping? prefixMapping;

--- a/test/core/thing_description_test.dart
+++ b/test/core/thing_description_test.dart
@@ -37,11 +37,7 @@ void main() {
     };
     final thingDescription = thingDescriptionJson.toThingDescription();
 
-    // TODO(JKRhb): Implement toJson method
-    expect(
-      thingDescription.toJson,
-      throwsUnimplementedError,
-    );
+    expect(thingDescriptionJson, thingDescription.toJson());
   });
 
   test("should throw a ValidationException when it is invalid during parsing",


### PR DESCRIPTION
This PR adds a very basic implementation for the “conversion” of a `ThingDescription` to a `Map<String, dynamic>` object via the `toJson` method. This is done by keeping a reference to the `Map` object that is being passed into the named `fromJson` constructor.

The implementation is not the most elegant and should be reworked/made more efficient in follow-up PRs; however, for now it closes a gap that caused an `UnimplementedError` to be thrown until now when someone would have called that method, crashing the application, which is not really desirable. Therefore, this PR makes the library a bit more usable in practice.