### PR TITLE
feat(context.dart): add getter for default language code

### DIFF
--- a/lib/src/core/definitions/context.dart
+++ b/lib/src/core/definitions/context.dart
@@ -85,6 +85,13 @@ final class Context {
   /// Used to map context extension prefixes within the `@context` to URIs.
   final PrefixMapping prefixMapping;
 
+  /// Determines the default language for this `@context` if defined.
+  String? get defaultLanguageCode => contextEntries
+      .whereType<MapContextEntry>()
+      .where((contextEntry) => contextEntry.key == "@language")
+      .firstOrNull
+      ?.value;
+
   /// Allows for directly accessing this [Context]'s [contextEntries] by
   /// [index].
   ContextEntry operator [](int index) {

--- a/test/core/context_test.dart
+++ b/test/core/context_test.dart
@@ -59,6 +59,20 @@ void main() {
       );
     });
 
+    test("support determining the default language via the dedicated getter",
+        () {
+      final context1 = Context([
+        SingleContextEntry.fromString("https://www.w3.org/2022/wot/td/v1.1"),
+        const StringMapContextEntry("@language", "en"),
+      ]);
+      final context2 = Context([
+        SingleContextEntry.fromString("https://www.w3.org/2022/wot/td/v1.1"),
+      ]);
+
+      expect(context1.defaultLanguageCode, "en");
+      expect(context2.defaultLanguageCode, null);
+    });
+
     test("correctly override the hashCode getter", () {
       final contextEntry1 =
           SingleContextEntry.fromString("https://www.w3.org/2022/wot/td/v1.1");


### PR DESCRIPTION
This PR adds a shortcut for determining the default language code (if present) via the TD @context.