### PR TITLE
feat!: allow for consuming the same TD twice

### DIFF
--- a/lib/src/core/implementation/consumed_thing.dart
+++ b/lib/src/core/implementation/consumed_thing.dart
@@ -417,7 +417,7 @@ class ConsumedThing implements scripting_api.ConsumedThing {
   }
 
   /// Cleans up the resources used by this [ConsumedThing].
-  void destroy() {
+  bool destroy({bool external = true}) {
     for (final observedProperty in _observedProperties.values) {
       observedProperty.stop();
     }
@@ -426,5 +426,11 @@ class ConsumedThing implements scripting_api.ConsumedThing {
       subscribedEvent.stop();
     }
     _subscribedEvents.clear();
+
+    if (external) {
+      return servient.deregisterConsumedthing(this);
+    }
+
+    return false;
   }
 }

--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -51,7 +51,7 @@ class Servient {
   final List<ProtocolServer> _servers = [];
   final Map<String, ProtocolClientFactory> _clientFactories = {};
   final Map<String, ExposedThing> _things = {};
-  final Map<String, ConsumedThing> _consumedThings = {};
+  final Set<ConsumedThing> _consumedThings = {};
 
   final ServerSecurityCallback? _serverSecurityCallback;
 
@@ -85,7 +85,7 @@ class Servient {
       clientFactory.destroy();
     }
     _clientFactories.clear();
-    for (final consumedThing in _consumedThings.values) {
+    for (final consumedThing in _consumedThings) {
       consumedThing.destroy();
     }
     _consumedThings.clear();
@@ -135,20 +135,20 @@ class Servient {
     return true;
   }
 
-  /// Removes and cleans up the resources of the [ConsumedThing] with the given
-  /// [id].
+  /// Removes and cleans up the resources of a [ConsumedThing].
   ///
   /// If the [ConsumedThing] has not been registered before, `false` is
   /// returned, otherwise `true`.
-  bool destroyConsumedThing(String id) {
-    final existingThing = _consumedThings.remove(id);
+  bool destroyConsumedThing(ConsumedThing consumedThing) {
+    return consumedThing.destroy(external: false);
+  }
 
-    if (existingThing != null) {
-      existingThing.destroy();
-      return true;
-    }
-
-    return false;
+  /// Deregisters the given [consumedThing].
+  ///
+  /// If the [ConsumedThing] has not been registered before, `false` is
+  /// returned, otherwise `true`.
+  bool deregisterConsumedthing(ConsumedThing consumedThing) {
+    return _consumedThings.remove(consumedThing);
   }
 
   /// Adds a [ConsumedThing] to the servient if it hasn't been registered
@@ -156,15 +156,7 @@ class Servient {
   ///
   /// Returns `false` if the [thing] has already been registered, otherwise
   /// `true`.
-  bool addConsumedThing(ConsumedThing thing) {
-    final id = thing.identifier;
-    if (_consumedThings.containsKey(id)) {
-      return false;
-    }
-
-    _consumedThings[id] = thing;
-    return true;
-  }
+  bool addConsumedThing(ConsumedThing thing) => _consumedThings.add(thing);
 
   /// Returns an [ExposedThing] with the given [id] if it has been registered.
   ExposedThing? thing(String id) => _things[id];

--- a/lib/src/core/implementation/wot.dart
+++ b/lib/src/core/implementation/wot.dart
@@ -35,12 +35,9 @@ class WoT implements scripting_api.WoT {
     ThingDescription thingDescription,
   ) async {
     final newThing = ConsumedThing(_servient, thingDescription);
-    if (_servient.addConsumedThing(newThing)) {
-      return newThing;
-    } else {
-      final id = thingDescription.identifier;
-      throw DartWotException(id);
-    }
+    _servient.addConsumedThing(newThing);
+
+    return newThing;
   }
 
   /// Exposes a Thing based on a (partial) TD.

--- a/test/core/consumed_thing_test.dart
+++ b/test/core/consumed_thing_test.dart
@@ -262,7 +262,6 @@ void main() {
       );
 
       await servient.shutdown();
-      expect(servient.destroyConsumedThing(parsedTd.identifier), false);
     },
     skip: true, // TODO: Replace with test with local server
   );

--- a/test/core/wot_test.dart
+++ b/test/core/wot_test.dart
@@ -9,7 +9,7 @@ import "package:test/test.dart";
 
 void main() {
   group("WoT should", () {
-    test("throw an execption when consuming the same TD twice", () async {
+    test("not throw an execption when consuming the same TD twice", () async {
       const thingDescriptionJson = {
         "@context": "https://www.w3.org/2022/wot/td/v1.1",
         "title": "Test Thing",
@@ -22,9 +22,9 @@ void main() {
 
       final wot = await Servient().start();
 
-      await wot.consume(thingDescription);
-      final result = wot.consume(thingDescription);
-      await expectLater(result, throwsA(isA<DartWotException>()));
+      final firstConsumedThing = await wot.consume(thingDescription);
+      final secondConsumedThing = await wot.consume(thingDescription);
+      expect(firstConsumedThing != secondConsumedThing, isTrue);
     });
 
     test(


### PR DESCRIPTION
In the context of #133, I have noticed that the `consume` method currently throws an exception if you want to consume the same Thing Description twice (or rather: two Thing Descriptions that have the same “identifier”), which can have unintended consequences when performing discovery.

This PR fixes the issue for now by changing the internal data structure from a `Map` to a `Set` and not checking for the presence of a Thing Description (using its `id` or `title`) anymore. This change is not really optimal and can only be considered a workaround, which I will properly fix as part of a general overhaul of the `Servient` API (which currently exposes too much API surface to the library user). That overhaul will be the next aspect of the library I will work on.