### PR TITLE
feat!: rework Servient API

### DIFF
--- a/example/coap_discovery.dart
+++ b/example/coap_discovery.dart
@@ -37,9 +37,9 @@ Future<void> handleThingDescription(
 }
 
 Future<void> main(List<String> args) async {
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [CoapClientFactory()],
-    discoveryConfiguration: [
+    discoveryConfigurations: [
       DirectConfiguration(
         Uri.parse("coap://plugfest.thingweb.io:5683/testthing"),
       ),

--- a/example/coap_dns_sd_discovery.dart
+++ b/example/coap_dns_sd_discovery.dart
@@ -14,12 +14,12 @@ void handleThingDescription(ThingDescription thingDescription) =>
     print('Discovered TD with title "${thingDescription.title}".');
 
 Future<void> main(List<String> args) async {
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       CoapClientFactory(),
       HttpClientFactory(),
     ],
-    discoveryConfiguration: [
+    discoveryConfigurations: [
       DnsSdDConfiguration(protocolType: ProtocolType.udp),
     ],
   );

--- a/example/coaps_readproperty.dart
+++ b/example/coaps_readproperty.dart
@@ -37,7 +37,7 @@ Future<void> main(List<String> args) async {
     pskCredentialsCallback: _pskCredentialsCallback,
   );
 
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       coapClientFactory,
     ],

--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -98,7 +98,7 @@ Future<void> main() async {
   final httpClientFactory =
       HttpClientFactory(basicCredentialsCallback: basicCredentialsCallback);
 
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       coapClientFactory,
       httpClientFactory,

--- a/example/core_link_format_discovery.dart
+++ b/example/core_link_format_discovery.dart
@@ -10,9 +10,9 @@ import "package:dart_wot/binding_coap.dart";
 import "package:dart_wot/core.dart";
 
 Future<void> main(List<String> args) async {
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [CoapClientFactory()],
-    discoveryConfiguration: [
+    discoveryConfigurations: [
       CoreLinkFormatConfiguration(
         Uri.parse("coap://plugfest.thingweb.io"),
       ),

--- a/example/directory_discovery.dart
+++ b/example/directory_discovery.dart
@@ -10,7 +10,7 @@ import "package:dart_wot/binding_http.dart";
 import "package:dart_wot/core.dart";
 
 Future<void> main(List<String> args) async {
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       HttpClientFactory(),
     ],

--- a/example/example.dart
+++ b/example/example.dart
@@ -11,7 +11,7 @@ import "package:dart_wot/binding_http.dart";
 import "package:dart_wot/core.dart";
 
 Future<void> main(List<String> args) async {
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       CoapClientFactory(),
       HttpClientFactory(),

--- a/example/http_basic_authentication.dart
+++ b/example/http_basic_authentication.dart
@@ -61,7 +61,7 @@ Future<void> main(List<String> args) async {
   final httpClientFactory = HttpClientFactory(
     basicCredentialsCallback: basicCredentialsCallback,
   );
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       httpClientFactory,
     ],

--- a/example/mqtt_example.dart
+++ b/example/mqtt_example.dart
@@ -60,7 +60,7 @@ Future<BasicCredentials?> basicCredentialsCallback(
 }
 
 Future<void> main(List<String> args) async {
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       MqttClientFactory(basicCredentialsCallback: basicCredentialsCallback),
     ],

--- a/lib/src/core/implementation.dart
+++ b/lib/src/core/implementation.dart
@@ -15,4 +15,4 @@ export "implementation/discovery/discovery_configuration.dart";
 export "implementation/protocol_interfaces/protocol_client.dart";
 export "implementation/protocol_interfaces/protocol_client_factory.dart";
 export "implementation/protocol_interfaces/protocol_server.dart";
-export "implementation/servient.dart";
+export "implementation/servient.dart" show Servient;

--- a/lib/src/core/implementation/consumed_thing.dart
+++ b/lib/src/core/implementation/consumed_thing.dart
@@ -20,7 +20,7 @@ class ConsumedThing implements scripting_api.ConsumedThing {
       : title = thingDescription.title;
 
   /// The [Servient] corresponding with this [ConsumedThing].
-  final Servient servient;
+  final InternalServient servient;
 
   @override
   final ThingDescription thingDescription;
@@ -428,7 +428,7 @@ class ConsumedThing implements scripting_api.ConsumedThing {
     _subscribedEvents.clear();
 
     if (external) {
-      return servient.deregisterConsumedthing(this);
+      return servient.deregisterConsumedThing(this);
     }
 
     return false;

--- a/lib/src/core/implementation/thing_discovery.dart
+++ b/lib/src/core/implementation/thing_discovery.dart
@@ -26,7 +26,7 @@ class ThingDiscovery extends Stream<ThingDescription>
     _stream = _start();
   }
 
-  final Servient _servient;
+  final InternalServient _servient;
 
   final Map<String, ProtocolClient> _clients = {};
 
@@ -43,7 +43,7 @@ class ThingDiscovery extends Stream<ThingDescription>
   late final Stream<ThingDescription> _stream;
 
   Stream<ThingDescription> _start() async* {
-    for (final discoveryParameter in _servient.discoveryConfiguration) {
+    for (final discoveryParameter in _servient.discoveryConfigurations) {
       switch (discoveryParameter) {
         case DnsSdDConfiguration(
             :final discoveryType,

--- a/test/binding_http/http_test.dart
+++ b/test/binding_http/http_test.dart
@@ -6,6 +6,7 @@
 
 import "package:dart_wot/binding_http.dart";
 import "package:dart_wot/core.dart";
+import "package:dart_wot/src/core/implementation/servient.dart";
 import "package:mockito/annotations.dart";
 import "package:test/test.dart";
 import "http_test.mocks.dart";
@@ -116,7 +117,7 @@ void main() {
         ]) async =>
             bearerCredentialsStore[uri.host];
 
-        final servient = Servient(
+        final servient = InternalServient(
           clientFactories: [
             HttpClientFactory(
               basicCredentialsCallback: basicCredentialsCallback,

--- a/test/core/consumed_thing_test.dart
+++ b/test/core/consumed_thing_test.dart
@@ -238,7 +238,7 @@ void main() {
 
       final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
 
-      final servient = Servient(clientFactories: [HttpClientFactory()]);
+      final servient = Servient.create(clientFactories: [HttpClientFactory()]);
       final wot = await servient.start();
 
       final uriVariables = {"value": "SFRUUEJJTiBpcyBhd2Vzb21l"};
@@ -278,7 +278,7 @@ void main() {
 
     final parsedTd = ThingDescription.fromJson(thingDescriptionJson);
 
-    final servient = Servient();
+    final servient = Servient.create();
     final wot = await servient.start();
 
     final consumedThing = await wot.consume(parsedTd);

--- a/test/core/dart_wot_test.dart
+++ b/test/core/dart_wot_test.dart
@@ -18,7 +18,7 @@ void main() {
     test(
       "Parse incomplete Thing Description",
       () async {
-        final servient = Servient();
+        final servient = Servient.create();
         final wot = await servient.start();
         final Map<String, dynamic> exposedThingInit = <String, dynamic>{
           "@context": "https://www.w3.org/2022/wot/td/v1.1",

--- a/test/core/discovery_test.dart
+++ b/test/core/discovery_test.dart
@@ -279,7 +279,7 @@ extension _DiscoveryContentCreationExtension on String {
 void main() {
   group("requestThingDescription()", () {
     test("should be able to retrieve a valid TD", () async {
-      final servient = Servient(
+      final servient = Servient.create(
         clientFactories: [
           _MockedProtocolClientFactory(),
         ],
@@ -295,7 +295,7 @@ void main() {
     test(
       "should throw an exception when an invalid TD is retrieved",
       () async {
-        final servient = Servient(
+        final servient = Servient.create(
           clientFactories: [
             _MockedProtocolClientFactory(),
           ],
@@ -313,7 +313,7 @@ void main() {
 
   group("exploreDirectory()", () {
     test("should be able to discover valid TDs from a TD directory", () async {
-      final servient = Servient(
+      final servient = Servient.create(
         clientFactories: [
           _MockedProtocolClientFactory(),
         ],
@@ -333,7 +333,7 @@ void main() {
     });
 
     test("should reject invalid TDD Thing Descriptions", () async {
-      final servient = Servient(
+      final servient = Servient.create(
         clientFactories: [
           _MockedProtocolClientFactory(),
         ],
@@ -349,7 +349,7 @@ void main() {
 
     test("should be able to handle an array of invalid TDs during discovery",
         () async {
-      final servient = Servient(
+      final servient = Servient.create(
         clientFactories: [
           _MockedProtocolClientFactory(),
         ],
@@ -382,7 +382,7 @@ void main() {
     test(
         "should be able to handle an invalid non-array output during discovery",
         () async {
-      final servient = Servient(
+      final servient = Servient.create(
         clientFactories: [
           _MockedProtocolClientFactory(),
         ],
@@ -397,7 +397,7 @@ void main() {
     });
 
     test("should be able to handle premature cancellation", () async {
-      final servient = Servient(
+      final servient = Servient.create(
         clientFactories: [
           _MockedProtocolClientFactory(),
         ],
@@ -416,7 +416,7 @@ void main() {
     });
 
     test("should support the experimental query parameters API", () async {
-      final servient = Servient(
+      final servient = Servient.create(
         clientFactories: [
           _MockedProtocolClientFactory(),
         ],
@@ -442,7 +442,7 @@ void main() {
     test(
         'should currently not support the "collection" format when using the '
         "experimental query parameters API", () async {
-      final servient = Servient();
+      final servient = Servient.create();
       final wot = await servient.start();
 
       expect(

--- a/test/core/servient_test.dart
+++ b/test/core/servient_test.dart
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import "package:dart_wot/core.dart";
+import "package:dart_wot/src/core/implementation/servient.dart";
 import "package:test/test.dart";
 
 const testUriScheme = "test";
@@ -37,7 +38,7 @@ void main() {
   group("Servient", () {
     test("should accept a ProtocolClientFactory list as constructor argument",
         () {
-      final servient = Servient(
+      final servient = InternalServient(
         clientFactories: [
           MockedProtocolClientFactory(),
         ],
@@ -49,7 +50,7 @@ void main() {
     test(
       "should allow for adding and removing a ProtocolClientFactory at runtime",
       () {
-        final servient = Servient()
+        final servient = InternalServient()
           ..addClientFactory(MockedProtocolClientFactory());
 
         expect(servient.clientSchemes.contains(testUriScheme), true);
@@ -66,7 +67,7 @@ void main() {
     "should throw a DartWotException when a "
     "ProtocolClientFactory is not registered",
     () {
-      final servient = Servient();
+      final servient = InternalServient();
 
       expect(
         () => servient.clientFor(testUriScheme),

--- a/test/core/wot_test.dart
+++ b/test/core/wot_test.dart
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import "package:dart_wot/core.dart";
+import "package:dart_wot/src/core/implementation/servient.dart";
 import "package:test/test.dart";
 
 void main() {
@@ -20,7 +21,7 @@ void main() {
       };
       final thingDescription = thingDescriptionJson.toThingDescription();
 
-      final wot = await Servient().start();
+      final wot = await InternalServient().start();
 
       final firstConsumedThing = await wot.consume(thingDescription);
       final secondConsumedThing = await wot.consume(thingDescription);
@@ -40,7 +41,7 @@ void main() {
         "id": "urn:test",
       };
 
-      final wot = await Servient().start();
+      final wot = await InternalServient().start();
 
       await wot.produce(exposedThingInit);
       final result = wot.produce(exposedThingInit);


### PR DESCRIPTION
This PR reworks the API exposed by the `Servient`, making it more convenient and “safer” to use, by reducing the API surface that is exposed to library users.

In order to achieve this, I converted the `Servient` class into an abstract one, that instantiates a hidden `InternalServient` class via a factory constructor. This makes creating a new `Servient` a bit less “clean” since you need to call `create()` to instantiate the `Servient` now – but I think that is a tradeoff that is tolerable.

As a next step, the `InternalServient` as well as the implementations of the `ConsumedThing` and the `ExposedThing` interfaces can be improved internally. Furthermore, since all implementation details are now handled within the `InternalServient`, it should be easier to add new features, especially when it comes to discovery.