### PR TITLE
ci: add missing codecov token for code coverage determination

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
 
       - uses: codecov/codecov-action@v3
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           file: coverage/lcov.info
           name: Upload to codecov.io
           verbose: true


### PR DESCRIPTION
Related to https://github.com/eclipse-thingweb/.eclipsefdn/issues/18, this PR adds the CODECOV_TOKEN back as an argument for the codecov upload step into the respective workflow file.

As mentioned in https://github.com/eclipse-thingweb/.eclipsefdn/issues/18, the token should be updated, however, to point to the correct location on codecov itself (as currently, it is still referring to the namib-project there).