### PR TITLE
chore: use Thingweb bot for release preparation

### DIFF
--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -9,6 +9,10 @@ permissions:
   contents: write
   pull-requests: write
 
+env:
+  BOT_USER_NAME: eclipse-thingweb-bot
+  BOT_EMAIL: thingweb-bot@eclipse.org
+
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
@@ -53,10 +57,11 @@ jobs:
         id: cpr
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.BOT_TOKEN }}
           commit-message: "chore(release): prepare release ${{ steps.version-number.outputs.version }}"
-          committer: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
-          author: github-actions[bot] <github-actions[bot]@users.noreply.github.com>
+          committer: ${{ env.BOT_USER_NAME }} <${{ env.BOT_EMAIL }}>
+          author: ${{ env.BOT_USER_NAME }} <${{ env.BOT_EMAIL }}>
+
           signoff: true
           branch: next-release
           delete-branch: true


### PR DESCRIPTION
This PR will probably incorporate the solution found in https://github.com/eclipse-thingweb/.eclipsefdn/pull/21, resolving the issues currently experienced in the context of #144.