### PR TITLE
Fix documentation comments

### DIFF
--- a/lib/src/binding_coap/coap_config.dart
+++ b/lib/src/binding_coap/coap_config.dart
@@ -48,7 +48,7 @@ class CoapConfig {
   /// Indicates if multicast should be available for discovery.
   ///
   /// Defaults to false for security reasons, as multicast can lead to
-  /// amplication scenarios/attacks (c.f., [WoT Discovery Specification]).
+  /// amplification scenarios/attacks (c.f., [WoT Discovery Specification]).
   ///
   /// [WoT Discovery Specification]: https://w3c.github.io/wot-discovery/#security-consideration-amp-ddos
   final bool allowMulticastDiscovery;

--- a/lib/src/binding_mqtt/mqtt_client_factory.dart
+++ b/lib/src/binding_mqtt/mqtt_client_factory.dart
@@ -12,7 +12,7 @@ import "mqtt_config.dart";
 
 /// [ProtocolClientFactory] for creating [MqttClient]s.
 final class MqttClientFactory implements ProtocolClientFactory {
-  /// Instatiates a new [MqttClientFactory].
+  /// Instantiates a new [MqttClientFactory].
   MqttClientFactory({
     MqttConfig? mqttConfig,
     AsyncClientSecurityCallback<BasicCredentials>? basicCredentialsCallback,

--- a/lib/src/core/definitions/credentials/callbacks.dart
+++ b/lib/src/core/definitions/credentials/callbacks.dart
@@ -58,7 +58,7 @@ typedef AceSecurityCallback = Future<AceCredentials?> Function(
 /// argument.
 ///
 /// This callback signature is currently only used for [PskCredentials] due to
-/// implementation limititations, which do not allow for asynchronous callbacks.
+/// implementation limitations, which do not allow for asynchronous callbacks.
 typedef AsyncClientSecurityCallback<T extends Credentials> = Future<T?>
     Function(Uri uri, AugmentedForm? form, T? invalidCredentials);
 

--- a/lib/src/core/definitions/extensions/json_parser.dart
+++ b/lib/src/core/definitions/extensions/json_parser.dart
@@ -217,7 +217,7 @@ extension ParseField on Map<String, dynamic> {
   /// Parses a field with a given [name] as a [Map] of [DataSchema]s.
   ///
   /// Returns `null` if the field should not be present or if it is not a
-  /// JSON object contaning other objects.
+  /// JSON object containing other objects.
   ///
   /// If a [Set] of [parsedFields] is passed to this function, the field [name]
   /// will added. This can be used for filtering when parsing additional fields.
@@ -244,7 +244,7 @@ extension ParseField on Map<String, dynamic> {
 
   /// Parses [Form]s contained in this JSON object.
   ///
-  /// Epands compact URIs using the given [prefixMapping] and adds the key
+  /// Expands compact URIs using the given [prefixMapping] and adds the key
   /// `forms` to the set of [parsedFields], if defined.
   List<Form>? parseForms(
     PrefixMapping prefixMapping,

--- a/lib/src/core/definitions/interaction_affordances/interaction_affordance.dart
+++ b/lib/src/core/definitions/interaction_affordances/interaction_affordance.dart
@@ -36,13 +36,13 @@ sealed class InteractionAffordance {
   /// The default [title] of this [InteractionAffordance].
   final String? title;
 
-  /// Multilanguage [titles] of this [InteractionAffordance].
+  /// Multi-language [titles] of this [InteractionAffordance].
   final Map<String, String>? titles;
 
   /// The default [description] of this [InteractionAffordance].
   final String? description;
 
-  /// Multilanguage [descriptions] of this [InteractionAffordance].
+  /// Multi-language [descriptions] of this [InteractionAffordance].
   final Map<String, String>? descriptions;
 
   /// The basic [forms] which can be used for interacting with this resource.

--- a/lib/src/core/implementation/augmented_form.dart
+++ b/lib/src/core/implementation/augmented_form.dart
@@ -12,7 +12,7 @@ import "package:uri/uri.dart";
 import "../definitions.dart";
 import "../exceptions.dart";
 
-/// A [Form] augmented with information from its asscociated [_thingDescription]
+/// A [Form] augmented with information from its associated [_thingDescription]
 /// and [_interactionAffordance].
 @immutable
 final class AugmentedForm implements Form {

--- a/lib/src/core/implementation/content_serdes.dart
+++ b/lib/src/core/implementation/content_serdes.dart
@@ -193,7 +193,7 @@ class ContentSerdes {
   /// Converts a [Content] object to a typed [Object].
   ///
   /// A [dataSchema] can be passed for validating the result. If the media type
-  /// specified in the [content] is not supported, the method willl try to
+  /// specified in the [content] is not supported, the method will try to
   /// convert its body to an UTF-8 string.
   Future<DataSchemaValue<Object?>?> contentToValue(
     Content content,

--- a/lib/src/core/implementation/discovery/discovery_configuration.dart
+++ b/lib/src/core/implementation/discovery/discovery_configuration.dart
@@ -154,7 +154,7 @@ final class DnsSdDConfiguration extends TwoStepConfiguration {
 final class CoreLinkFormatConfiguration extends TwoStepConfiguration {
   /// Instantiates a new [CoreLinkFormatConfiguration] object.
   ///
-  /// The [baseUrl] can either be a unicast or – when using a mulicast-capable
+  /// The [baseUrl] can either be a unicast or – when using a multicast-capable
   /// protocol such as CoAP – a multicast [Uri]. The default URI path used for
   /// discovering Thing Descriptions is the standardized `/.well-known/core`
   /// (see [RFC 6690, section 4]).
@@ -198,7 +198,7 @@ final class CoreLinkFormatConfiguration extends TwoStepConfiguration {
 final class CoreResourceDirectoryConfiguration extends TwoStepConfiguration {
   /// Instantiates a new [CoreResourceDirectoryConfiguration] object.
   ///
-  /// The [baseUrl] can either be a unicast or – when using a mulicast-capable
+  /// The [baseUrl] can either be a unicast or – when using a multicast-capable
   /// protocol such as CoAP – a multicast [Uri]. The default URI path used for
   /// discovering lookup interfaces of CoRE Resource Directories is the
   /// standardized URI path `/.well-known/core` (see [RFC 6690, section 4]).

--- a/lib/src/core/implementation/exposed_thing.dart
+++ b/lib/src/core/implementation/exposed_thing.dart
@@ -9,7 +9,7 @@ import "../scripting_api.dart" as scripting_api;
 
 import "servient.dart";
 
-/// Implemention of the [scripting_api.ExposedThing] interface.
+/// Implementation of the [scripting_api.ExposedThing] interface.
 class ExposedThing implements scripting_api.ExposedThing {
   /// Creates a new [ExposedThing] from a [servient] and an [exposedThingInit].
   ExposedThing(this.servient, scripting_api.ExposedThingInit exposedThingInit)

--- a/lib/src/core/implementation/protocol_interfaces/protocol_client_factory.dart
+++ b/lib/src/core/implementation/protocol_interfaces/protocol_client_factory.dart
@@ -14,7 +14,7 @@ abstract interface class ProtocolClientFactory {
   /// The protocol [schemes] support of the clients this factory produces.
   Set<String> get schemes;
 
-  /// Initalizes this [ProtocolClientFactory].
+  /// Initializes this [ProtocolClientFactory].
   ///
   /// Returns `true` on success.
   bool init();

--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -59,7 +59,7 @@ abstract class Servient {
     List<DiscoveryConfiguration> discoveryConfigurations,
   );
 
-  /// Starts this [Servient] and returns a [WoT] runtime object.
+  /// Starts this [Servient] and returns a [scripting_api.WoT] runtime object.
   ///
   /// The [scripting_api.WoT] runtime can be used for consuming, producing, and
   /// discovering Things.

--- a/lib/src/core/implementation/thing_discovery.dart
+++ b/lib/src/core/implementation/thing_discovery.dart
@@ -18,7 +18,7 @@ import "discovery/discovery_configuration.dart";
 import "protocol_interfaces/protocol_client.dart";
 import "servient.dart";
 
-/// Implemention of the [scripting_api.ThingDiscovery] interface.
+/// Implementation of the [scripting_api.ThingDiscovery] interface.
 class ThingDiscovery extends Stream<ThingDescription>
     implements scripting_api.ThingDiscovery {
   /// Creates a new [ThingDiscovery] object with a given [thingFilter].
@@ -337,7 +337,7 @@ extension _UriExtension on Uri {
   }
 }
 
-/// Implemention of the [scripting_api.ThingDiscoveryProcess] interface.
+/// Implementation of the [scripting_api.ThingDiscoveryProcess] interface.
 class ThingDiscoveryProcess extends Stream<ThingDescription>
     implements scripting_api.ThingDiscoveryProcess {
   /// Constructs a new [ThingDiscoveryProcess].


### PR DESCRIPTION
Inspired by @danielpeintner, I went through all the files with a spellchecker and found a number of typos and other smaller issues. This PR applies a first round of fixes to the documentation comments.