### PR TITLE
ci: fix git tag reference automated GitHub releases

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -39,7 +39,7 @@ jobs:
         if: ${{ steps.tag-check.outputs.new-tag != '' }}
         with:
           config: cliff.toml
-          args: --verbose --unreleased --strip header --tag ${{ steps.pubspec-version-number.outputs.pubspec-version }}
+          args: --verbose --unreleased --strip header --tag ${{ steps.tag-check.outputs.new-tag }}
         env:
           OUTPUT: CHANGES.md
           GITHUB_REPO: ${{ github.repository }}


### PR DESCRIPTION
Inspecting the release notes for the first fully automated release [0.31.0](https://github.com/eclipse-thingweb/dart_wot/releases/tag/v0.31.0), I noticed that the links included in the release notes used the wrong format (`0.31.0` instead of `v0.31.0`) for referencing the git tag associated with the release.

This PR applies a simple fix for that by slightly adjusting the GitHub Actions workflow definition.

