### PR TITLE
docs(README.md): use new Servient API in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ import "package:dart_wot/binding_http.dart";
 import "package:dart_wot/core.dart";
 
 Future<void> main(List<String> args) async {
-  final servient = Servient(
+  final servient = Servient.create(
     clientFactories: [
       CoapClientFactory(),
       HttpClientFactory(),


### PR DESCRIPTION
In https://github.com/eclipse-thingweb/dart_wot/pull/142, I forgot to update the example in the README file. This PR makes it usable again.