### PR TITLE
fix(binding_mqtt): fix disconnect of client after reading a resource

### DIFF
--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -140,13 +140,15 @@ final class MqttClient implements ProtocolClient {
         final payload = publishedMessage.payload.message;
 
         completer.complete(Content(form.contentType, Stream.value(payload)));
-        client.disconnect();
         timer.cancel();
         break;
       }
     });
 
-    return completer.future;
+    final content = await completer.future;
+    client.disconnect();
+
+    return content;
   }
 
   @override


### PR DESCRIPTION
When trying to run the MQTT example, there was currently an error being thrown that stated that it “[c]annot fire new event. Controller is already firing an event” when the binding implementation was trying to call `disconnect` on the respective `MqttServerClient`.

This PR slightly alters the way the `disconnect` method is being thrown, thus solving the issue.