### PR TITLE
docs(scripting_api): fix typo in Subscription interface

### DIFF
--- a/lib/src/core/scripting_api/subscription.dart
+++ b/lib/src/core/scripting_api/subscription.dart
@@ -27,7 +27,7 @@ enum SubscriptionType {
 
 /// Represents a subscription to Property change and Event interactions.
 abstract interface class Subscription {
-  /// Denotes whether the subsciption is active, i.e. it is not stopped because
+  /// Denotes whether the subscription is active, i.e. it is not stopped because
   /// of an error or because of invocation of the [stop] method.
   bool get active;
 


### PR DESCRIPTION
This PR fixes a small typo in a documentation comment.