### PR TITLE
refactor(core): create separate module for protocol_interfaces

### DIFF
--- a/lib/core.dart
+++ b/lib/core.dart
@@ -12,4 +12,5 @@ library core;
 export "src/core/definitions.dart";
 export "src/core/exceptions.dart";
 export "src/core/implementation.dart";
+export "src/core/protocol_interfaces.dart";
 export "src/core/scripting_api.dart";

--- a/lib/src/core/implementation.dart
+++ b/lib/src/core/implementation.dart
@@ -12,7 +12,4 @@ export "implementation/codecs/content_codec.dart";
 export "implementation/content.dart";
 export "implementation/content_serdes.dart";
 export "implementation/discovery/discovery_configuration.dart";
-export "implementation/protocol_interfaces/protocol_client.dart";
-export "implementation/protocol_interfaces/protocol_client_factory.dart";
-export "implementation/protocol_interfaces/protocol_server.dart";
 export "implementation/servient.dart" show Servient;

--- a/lib/src/core/implementation/consumed_thing.dart
+++ b/lib/src/core/implementation/consumed_thing.dart
@@ -6,11 +6,12 @@
 
 import "../definitions.dart";
 import "../exceptions.dart";
+import "../protocol_interfaces.dart";
 import "../scripting_api.dart" as scripting_api;
+
 import "augmented_form.dart";
 import "content.dart";
 import "interaction_output.dart";
-import "protocol_interfaces/protocol_client.dart";
 import "servient.dart";
 
 /// Implementation of the [scripting_api.ConsumedThing] interface.

--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -10,14 +10,13 @@ import "package:uuid/uuid.dart";
 import "../definitions.dart";
 import "../definitions/context.dart";
 import "../exceptions.dart";
+import "../protocol_interfaces.dart";
 import "../scripting_api.dart" as scripting_api;
+
 import "consumed_thing.dart";
 import "content_serdes.dart";
 import "discovery/discovery_configuration.dart";
 import "exposed_thing.dart";
-import "protocol_interfaces/protocol_client.dart";
-import "protocol_interfaces/protocol_client_factory.dart";
-import "protocol_interfaces/protocol_server.dart";
 import "thing_discovery.dart";
 import "wot.dart";
 

--- a/lib/src/core/implementation/thing_discovery.dart
+++ b/lib/src/core/implementation/thing_discovery.dart
@@ -12,10 +12,11 @@ import "package:multicast_dns/multicast_dns.dart";
 
 import "../definitions.dart";
 import "../exceptions.dart";
+import "../protocol_interfaces.dart";
 import "../scripting_api.dart" as scripting_api;
+
 import "content.dart";
 import "discovery/discovery_configuration.dart";
-import "protocol_interfaces/protocol_client.dart";
 import "servient.dart";
 
 /// Implementation of the [scripting_api.ThingDiscovery] interface.

--- a/lib/src/core/protocol_interfaces.dart
+++ b/lib/src/core/protocol_interfaces.dart
@@ -1,0 +1,9 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+export "protocol_interfaces/protocol_client.dart";
+export "protocol_interfaces/protocol_client_factory.dart";
+export "protocol_interfaces/protocol_server.dart";

--- a/lib/src/core/protocol_interfaces/protocol_client.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client.dart
@@ -4,9 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "../../scripting_api/subscription.dart";
-import "../augmented_form.dart";
-import "../content.dart";
+import "../implementation.dart";
+import "../scripting_api.dart";
 
 /// Base class for a Protocol Client.
 abstract interface class ProtocolClient {

--- a/lib/src/core/protocol_interfaces/protocol_client_factory.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client_factory.dart
@@ -6,7 +6,7 @@
 
 import "package:meta/meta.dart";
 
-import "../../definitions.dart";
+import "../definitions.dart";
 import "protocol_client.dart";
 
 /// Base class for a factory that produces [ProtocolClient]s.

--- a/lib/src/core/protocol_interfaces/protocol_server.dart
+++ b/lib/src/core/protocol_interfaces/protocol_server.dart
@@ -4,8 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "../../definitions/credentials/callbacks.dart";
-import "../../scripting_api/exposed_thing.dart";
+import "../definitions/credentials/callbacks.dart";
+import "../scripting_api/exposed_thing.dart";
 
 /// Base class for a Protocol Server.
 abstract interface class ProtocolServer {


### PR DESCRIPTION
This PR reorganizes the project a bit by moving the `protocol_interfaces` up one level in the `core` directory.