### PR TITLE
Rework clean up of ConsumedThing

### DIFF
--- a/lib/src/binding_coap/coap_subscription.dart
+++ b/lib/src/binding_coap/coap_subscription.dart
@@ -8,15 +8,16 @@ import "package:coap/coap.dart";
 
 import "../../core.dart";
 
-/// [Subscription] to a CoAP resource, based on the observe option ([RFC 7641]).
+/// [ProtocolSubscription] to a CoAP resource, based on the observe option
+/// ([RFC 7641]).
 ///
 /// [RFC 7641]: https://datatracker.ietf.org/doc/html/rfc7641
-class CoapSubscription implements Subscription {
+final class CoapSubscription extends ProtocolSubscription {
   /// Constructor
   CoapSubscription(
     this._coapClient,
     this._observeClientRelation,
-    this._complete,
+    super._complete,
   ) : _active = true;
 
   final CoapClient _coapClient;
@@ -27,10 +28,6 @@ class CoapSubscription implements Subscription {
 
   @override
   bool get active => _active;
-
-  /// Callback used to pass by the servient that is used to signal it that an
-  /// observation has been cancelled.
-  final void Function() _complete;
 
   @override
   Future<void> stop({
@@ -48,6 +45,7 @@ class CoapSubscription implements Subscription {
       await _coapClient.cancelObserveProactive(observeClientRelation);
     }
     _coapClient.close();
-    _complete();
+    await super
+        .stop(formIndex: formIndex, uriVariables: uriVariables, data: data);
   }
 }

--- a/lib/src/binding_mqtt/mqtt_subscription.dart
+++ b/lib/src/binding_mqtt/mqtt_subscription.dart
@@ -9,13 +9,13 @@ import "package:mqtt_client/mqtt_server_client.dart";
 
 import "../../core.dart";
 
-/// [Subscription] for the MQTT protocol.
-class MqttSubscription implements Subscription {
+/// [ProtocolSubscription] for the MQTT protocol.
+final class MqttSubscription extends ProtocolSubscription {
   /// Constructor.
   MqttSubscription(
     this._form,
     this._client,
-    this._complete, {
+    super._complete, {
     required void Function(Content content) next,
     void Function(Exception error)? error,
   }) : _active = true {
@@ -52,8 +52,6 @@ class MqttSubscription implements Subscription {
 
   bool _active = true;
 
-  final void Function() _complete;
-
   @override
   bool get active => _active;
 
@@ -65,6 +63,7 @@ class MqttSubscription implements Subscription {
   }) async {
     _client.disconnect();
     _active = false;
-    _complete();
+    await super
+        .stop(formIndex: formIndex, uriVariables: uriVariables, data: data);
   }
 }

--- a/lib/src/core/implementation/consumed_thing.dart
+++ b/lib/src/core/implementation/consumed_thing.dart
@@ -416,22 +416,4 @@ class ConsumedThing implements scripting_api.ConsumedThing {
         _subscribedEvents.remove(key);
     }
   }
-
-  /// Cleans up the resources used by this [ConsumedThing].
-  bool destroy({bool external = true}) {
-    for (final observedProperty in _observedProperties.values) {
-      observedProperty.stop();
-    }
-    _observedProperties.clear();
-    for (final subscribedEvent in _subscribedEvents.values) {
-      subscribedEvent.stop();
-    }
-    _subscribedEvents.clear();
-
-    if (external) {
-      return servient.deregisterConsumedThing(this);
-    }
-
-    return false;
-  }
 }

--- a/lib/src/core/protocol_interfaces.dart
+++ b/lib/src/core/protocol_interfaces.dart
@@ -7,3 +7,4 @@
 export "protocol_interfaces/protocol_client.dart";
 export "protocol_interfaces/protocol_client_factory.dart";
 export "protocol_interfaces/protocol_server.dart";
+export "protocol_interfaces/protocol_subscription.dart";

--- a/lib/src/core/protocol_interfaces/protocol_subscription.dart
+++ b/lib/src/core/protocol_interfaces/protocol_subscription.dart
@@ -1,0 +1,30 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+import "package:meta/meta.dart";
+
+import "../scripting_api.dart";
+
+/// Base class for implementations of the [Subscription] interface.
+abstract base class ProtocolSubscription implements Subscription {
+  /// Instantiates a new [ProtocolSubscription].
+  ///
+  /// The [_complete] callback will be called when the [ProtocolSubscription]
+  /// has been [stop]ped (either internally or externally).
+  ProtocolSubscription(this._complete);
+
+  final void Function() _complete;
+
+  @override
+  @mustCallSuper
+  Future<void> stop({
+    int? formIndex,
+    Map<String, Object>? uriVariables,
+    Object? data,
+  }) async {
+    _complete();
+  }
+}


### PR DESCRIPTION
This PR reworks the relationship between `Servient`, `ConsumedThing`, and the `Subscription`s created when observing a property or subscribing to an event. It also removes the `ConsumedThing` cleanup code from the `Servient` class, which is not needed anymore now.

These changes decrease the coupling between the different parts of the codebase, making it overall more maintainable.