### PR TITLE
chore(analysis_options.yaml): report warnings for missing documentation

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,6 +2,10 @@
 
 include: package:lint/package.yaml
 
+analyzer:
+  errors:
+    public_member_api_docs: warning
+
 # Adjusted linting rules
 linter:
   rules:


### PR DESCRIPTION
Since (almost) 100% of the public API members have documentation provided, this PR enforces the addition of new documentation a bit more strictly by reporting a warning instead of an info message if no doc comment should be provided.

This could even be changed to an error later if the API should become completely stable; however, as the development process is still ongoing, that step is probably a bit too much at the moment.