### PR TITLE
docs(scripting_api): fix typo in DataSchemaValue documentation

### DIFF
--- a/lib/src/core/scripting_api/data_schema_value.dart
+++ b/lib/src/core/scripting_api/data_schema_value.dart
@@ -48,7 +48,7 @@ sealed class DataSchemaValue<T> {
   static ObjectValue fromObject(Map<String, dynamic> value) =>
       ObjectValue._fromValue(value);
 
-  /// Tries to instatiate a [DataSchemaValue] from a raw [value].
+  /// Tries to instantiate a [DataSchemaValue] from a raw [value].
   ///
   /// If the [value] is a non-valid data type, the method returns `null`
   /// instead.


### PR DESCRIPTION
This PR fixes another small typo in a documentation comment.