### PR TITLE
feat!: use base instead of interface for ProtocolClient class

### DIFF
--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -73,7 +73,7 @@ coap.PskCredentialsCallback? _createPskCallback(
 }
 
 /// A [ProtocolClient] for the Constrained Application Protocol (CoAP).
-final class CoapClient implements ProtocolClient {
+final class CoapClient extends ProtocolClient {
   /// Creates a new [CoapClient] based on an optional [CoapConfig].
   CoapClient({
     CoapConfig? coapConfig,

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -36,7 +36,7 @@ const _authorizationHeader = "Authorization";
 /// [RFC 7616]: https://datatracker.ietf.org/doc/html/rfc7616
 /// [RFC 6750]: https://datatracker.ietf.org/doc/html/rfc6750
 /// [`ComboSecurityScheme`]: https://w3c.github.io/wot-thing-description/#combosecurityscheme
-final class HttpClient implements ProtocolClient {
+final class HttpClient extends ProtocolClient {
   /// Creates a new [HttpClient].
   HttpClient({
     AsyncClientSecurityCallback<BasicCredentials>? basicCredentialsCallback,

--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -21,7 +21,7 @@ import "mqtt_subscription.dart";
 /// [ProtocolClient] for supporting the MQTT protocol.
 ///
 /// Currently, only MQTT version 3.1.1 is supported.
-final class MqttClient implements ProtocolClient {
+final class MqttClient extends ProtocolClient {
   /// Constructor.
   MqttClient({
     MqttConfig? mqttConfig,

--- a/lib/src/core/protocol_interfaces/protocol_client.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client.dart
@@ -8,7 +8,7 @@ import "../implementation.dart";
 import "../scripting_api.dart";
 
 /// Base class for a Protocol Client.
-abstract interface class ProtocolClient {
+abstract base class ProtocolClient {
   /// Starts this [ProtocolClient].
   Future<void> start();
 

--- a/test/core/discovery_test.dart
+++ b/test/core/discovery_test.dart
@@ -138,7 +138,7 @@ const invalidTestThingDescription2 = '''
   {"foo": "bar"}
 ''';
 
-class _MockedProtocolClient implements ProtocolClient {
+final class _MockedProtocolClient extends ProtocolClient {
   @override
   Stream<DiscoveryContent> discoverWithCoreLinkFormat(Uri uri) {
     // TODO: implement discoverWithCoreLinkFormat


### PR DESCRIPTION
As a step towards adding #167, this PR changes the class modifier of the `ProtocolClient` class from `interface` to `class`, making it possible to specify certain (discovery) functionalities via mixins.

As they alter the API of the core library, these are breaking changes.