### PR TITLE
fix(json_parser.dart): fix bug in link deserialization

### DIFF
--- a/lib/src/core/definitions/extensions/json_parser.dart
+++ b/lib/src/core/definitions/extensions/json_parser.dart
@@ -389,8 +389,10 @@ extension ParseField on Map<String, dynamic> {
     PrefixMapping prefixMapping,
     Set<String>? parsedFields,
   ) {
-    final fieldValue =
-        parseField<List<Map<String, dynamic>>>("links", parsedFields);
+    final fieldValue = parseArrayField<Map<String, dynamic>>(
+      "links",
+      parsedFields: parsedFields,
+    );
 
     return fieldValue?.map((e) => Link.fromJson(e, prefixMapping)).toList();
   }


### PR DESCRIPTION
This PR fixes a bug related to the deserialization of Links that probably got introduced with the merge of #172.