### PR TITLE
test(content_serdes_test.dart): address DataSchema FIXME comment

### DIFF
--- a/test/core/content_serdes_test.dart
+++ b/test/core/content_serdes_test.dart
@@ -146,8 +146,7 @@ void main() {
       expect(
         () => contentSerdes.valueToContent(
           null,
-          // FIXME(JKRhb): Should not be necessary to use fromJson here
-          DataSchema.fromJson(const {"type": "object"}, PrefixMapping()),
+          const DataSchema(type: "object"),
         ),
         throwsA(isA<FormatException>()),
       );


### PR DESCRIPTION
This PR addresses one left-over FIXME comment in one of the test files, where instead of the regular `DataSchema` constructor, the `fromJson` factory constructor was used (for some reason).