### PR TITLE
feat!: move discovery configurations to scripting_api package

### DIFF
--- a/example/coap_discovery.dart
+++ b/example/coap_discovery.dart
@@ -39,18 +39,19 @@ Future<void> handleThingDescription(
 Future<void> main(List<String> args) async {
   final servient = Servient.create(
     clientFactories: [CoapClientFactory()],
-    discoveryConfigurations: [
-      DirectConfiguration(
-        Uri.parse("coap://plugfest.thingweb.io:5683/testthing"),
-      ),
-    ],
   );
 
   final wot = await servient.start();
+  final discoveryConfigurations = [
+    DirectConfiguration(
+      Uri.parse("coap://plugfest.thingweb.io:5683/testthing"),
+    ),
+  ];
 
   // Example using for-await-loop
   try {
-    await for (final thingDescription in wot.discover()) {
+    await for (final thingDescription
+        in wot.discover(discoveryConfigurations)) {
       await handleThingDescription(wot, thingDescription);
     }
     print('Discovery with "await for" has finished.');
@@ -62,7 +63,7 @@ Future<void> main(List<String> args) async {
   //
   // Notice how the "onDone" callback is called before the result is passed
   // to the handleThingDescription function.
-  wot.discover().listen(
+  wot.discover(discoveryConfigurations).listen(
     (thingDescription) async {
       await handleThingDescription(wot, thingDescription);
     },

--- a/example/coap_dns_sd_discovery.dart
+++ b/example/coap_dns_sd_discovery.dart
@@ -19,16 +19,18 @@ Future<void> main(List<String> args) async {
       CoapClientFactory(),
       HttpClientFactory(),
     ],
-    discoveryConfigurations: [
-      const DnsSdDConfiguration(protocolType: ProtocolType.udp),
-    ],
   );
 
   final wot = await servient.start();
 
+  final discoveryConfigurations = [
+    const DnsSdDConfiguration(protocolType: ProtocolType.udp),
+  ];
+
   // Example using for-await-loop
   try {
-    await for (final thingDescription in wot.discover()) {
+    await for (final thingDescription
+        in wot.discover(discoveryConfigurations)) {
       handleThingDescription(thingDescription);
     }
     print('Discovery with "await for" has finished.');
@@ -40,7 +42,7 @@ Future<void> main(List<String> args) async {
   //
   // Notice how the "onDone" callback is called before the result is passed
   // to the handleThingDescription function.
-  wot.discover().listen(
+  wot.discover(discoveryConfigurations).listen(
         handleThingDescription,
         onError: (error) => print("Encountered an error: $error"),
         onDone: () => print('Discovery with "listen" has finished.'),

--- a/example/core_link_format_discovery.dart
+++ b/example/core_link_format_discovery.dart
@@ -12,16 +12,16 @@ import "package:dart_wot/core.dart";
 Future<void> main(List<String> args) async {
   final servient = Servient.create(
     clientFactories: [CoapClientFactory()],
-    discoveryConfigurations: [
-      CoreLinkFormatConfiguration(
-        Uri.parse("coap://plugfest.thingweb.io"),
-      ),
-    ],
   );
 
   final wot = await servient.start();
+  final discoveryConfigurations = [
+    CoreLinkFormatConfiguration(
+      Uri.parse("coap://plugfest.thingweb.io"),
+    ),
+  ];
 
-  await for (final thingDescription in wot.discover()) {
+  await for (final thingDescription in wot.discover(discoveryConfigurations)) {
     print(thingDescription.title);
 
     if (thingDescription.title != "Smart-Coffee-Machine") {

--- a/lib/src/core/implementation.dart
+++ b/lib/src/core/implementation.dart
@@ -11,5 +11,4 @@ export "implementation/augmented_form.dart";
 export "implementation/codecs/content_codec.dart";
 export "implementation/content.dart";
 export "implementation/content_serdes.dart";
-export "implementation/discovery/discovery_configuration.dart";
 export "implementation/servient.dart" show Servient;

--- a/lib/src/core/implementation/wot.dart
+++ b/lib/src/core/implementation/wot.dart
@@ -6,6 +6,8 @@
 
 import "dart:async";
 
+import "package:meta/meta.dart";
+
 import "../definitions.dart";
 import "../scripting_api.dart" as scripting_api;
 import "consumed_thing.dart";
@@ -39,10 +41,15 @@ class WoT implements scripting_api.WoT {
       _servient.produce(init);
 
   @override
-  ThingDiscovery discover({
+  ThingDiscovery discover(
+    @experimental
+    List<scripting_api.DiscoveryConfiguration> discoveryConfigurations, {
     scripting_api.ThingFilter? thingFilter,
   }) =>
-      _servient.discover(thingFilter: thingFilter);
+      _servient.discover(
+        discoveryConfigurations,
+        thingFilter: thingFilter,
+      );
 
   @override
   Future<ThingDescription> requestThingDescription(Uri url) =>

--- a/lib/src/core/scripting_api.dart
+++ b/lib/src/core/scripting_api.dart
@@ -12,6 +12,7 @@ library scripting_api;
 
 export "scripting_api/consumed_thing.dart";
 export "scripting_api/data_schema_value.dart";
+export "scripting_api/discovery/directory_payload_format.dart";
 export "scripting_api/discovery/thing_discovery.dart";
 export "scripting_api/discovery/thing_filter.dart";
 export "scripting_api/exposed_thing.dart";

--- a/lib/src/core/scripting_api.dart
+++ b/lib/src/core/scripting_api.dart
@@ -13,6 +13,7 @@ library scripting_api;
 export "scripting_api/consumed_thing.dart";
 export "scripting_api/data_schema_value.dart";
 export "scripting_api/discovery/directory_payload_format.dart";
+export "scripting_api/discovery/discovery_configuration.dart";
 export "scripting_api/discovery/thing_discovery.dart";
 export "scripting_api/discovery/thing_filter.dart";
 export "scripting_api/exposed_thing.dart";

--- a/lib/src/core/scripting_api/discovery/directory_payload_format.dart
+++ b/lib/src/core/scripting_api/discovery/directory_payload_format.dart
@@ -1,0 +1,34 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+/// Enumeration for specifying the value of the `format` query parameter when
+/// using the `exploreDirectory` discovery method.
+///
+/// See [section 7.3.2.1.5] of the [WoT Discovery] specification for more
+/// information.
+///
+/// [WoT Discovery]: https://www.w3.org/TR/2023/REC-wot-discovery-20231205
+/// [section 7.3.2.1.5]: https://www.w3.org/TR/2023/REC-wot-discovery-20231205/#exploration-directory-api-things-listing
+enum DirectoryPayloadFormat {
+  /// Indicates that an array of Thing Descriptions should be returned.
+  ///
+  /// This is the default value.
+  array,
+
+  /// Indicates that an collection of Thing Descriptions should be returned.
+  collection,
+  ;
+
+  @override
+  String toString() {
+    switch (this) {
+      case array:
+        return "array";
+      case collection:
+        return "collection";
+    }
+  }
+}

--- a/lib/src/core/scripting_api/discovery/discovery_configuration.dart
+++ b/lib/src/core/scripting_api/discovery/discovery_configuration.dart
@@ -6,7 +6,7 @@
 
 import "package:meta/meta.dart";
 
-import "../../scripting_api/discovery/thing_filter.dart";
+import "thing_filter.dart";
 
 /// Used to indicate whether the discovery mechanism will be used to discover
 /// Thing Descriptions of Things or Thing Description Directories.
@@ -92,6 +92,7 @@ enum ProtocolType {
 /// A configuration that is used by the `WoT.discover()` method when registered
 /// with the underlying `Servient`.
 @immutable
+@experimental
 sealed class DiscoveryConfiguration {
   const DiscoveryConfiguration();
 }
@@ -108,6 +109,7 @@ final class DirectConfiguration extends DiscoveryConfiguration {
 
 /// A configuration that is used for retrieving Thing Descriptions from a Thing
 /// Description Directory (TDD).
+@experimental
 final class ExploreDirectoryConfiguration extends DiscoveryConfiguration {
   /// Instantiates a new [ExploreDirectoryConfiguration].
   ///
@@ -183,6 +185,7 @@ final class MqttDiscoveryConfiguration extends DiscoveryConfiguration {
 /// These mechanisms first discover URLs pointing to Thing Descriptions
 /// (introduction phase) before retrieving the Thing Descriptions themselves
 /// (exploration phase).
+@experimental
 sealed class TwoStepConfiguration extends DiscoveryConfiguration {
   /// Creates a new [TwoStepConfiguration] object from a [discoveryType].
   const TwoStepConfiguration({required this.discoveryType});
@@ -229,6 +232,7 @@ final class DnsSdDConfiguration extends TwoStepConfiguration {
 /// Configures discovery using the CoRE link format ([RFC 6690]).
 ///
 /// [RFC 6690]: https://datatracker.ietf.org/doc/html/rfc6690
+@experimental
 final class CoreLinkFormatConfiguration extends TwoStepConfiguration {
   /// Instantiates a new [CoreLinkFormatConfiguration] object.
   ///
@@ -273,6 +277,7 @@ final class CoreLinkFormatConfiguration extends TwoStepConfiguration {
 /// Descriptions themselves.
 ///
 /// [RFC 9176]: https://datatracker.ietf.org/doc/html/rfc9176
+@experimental
 final class CoreResourceDirectoryConfiguration extends TwoStepConfiguration {
   /// Instantiates a new [CoreResourceDirectoryConfiguration] object.
   ///

--- a/lib/src/core/scripting_api/wot.dart
+++ b/lib/src/core/scripting_api/wot.dart
@@ -7,39 +7,11 @@
 import "../definitions.dart";
 
 import "consumed_thing.dart";
+import "discovery/directory_payload_format.dart";
 import "discovery/thing_discovery.dart";
 import "discovery/thing_filter.dart";
 import "exposed_thing.dart";
 import "types.dart";
-
-/// Enumeration for specifying the value of the `format` query parameter when
-/// using the `exploreDirectory` discovery method.
-///
-/// See [section 7.3.2.1.5] of the [WoT Discovery] specification for more
-/// information.
-///
-/// [WoT Discovery]: https://www.w3.org/TR/2023/REC-wot-discovery-20231205
-/// [section 7.3.2.1.5]: https://www.w3.org/TR/2023/REC-wot-discovery-20231205/#exploration-directory-api-things-listing
-enum DirectoryPayloadFormat {
-  /// Indicates that an array of Thing Descriptions should be returned.
-  ///
-  /// This is the default value.
-  array,
-
-  /// Indicates that an collection of Thing Descriptions should be returned.
-  collection,
-  ;
-
-  @override
-  String toString() {
-    switch (this) {
-      case array:
-        return "array";
-      case collection:
-        return "collection";
-    }
-  }
-}
 
 /// Interface for a [WoT] runtime.
 ///

--- a/lib/src/core/scripting_api/wot.dart
+++ b/lib/src/core/scripting_api/wot.dart
@@ -4,10 +4,13 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import "package:meta/meta.dart";
+
 import "../definitions.dart";
 
 import "consumed_thing.dart";
 import "discovery/directory_payload_format.dart";
+import "discovery/discovery_configuration.dart";
 import "discovery/thing_discovery.dart";
 import "discovery/thing_filter.dart";
 import "exposed_thing.dart";
@@ -46,7 +49,8 @@ abstract interface class WoT {
     DirectoryPayloadFormat? format,
   });
 
-  /// Discovers [ThingDescription]s using the underlying platform configuration.
+  /// Discovers [ThingDescription]s based on the provided
+  /// [discoveryConfigurations].
   ///
   /// A [thingFilter] may be passed for filtering out TDs before they
   /// are processed.
@@ -60,7 +64,11 @@ abstract interface class WoT {
   /// It also allows for stopping the Discovery process prematurely and
   /// for retrieving information about its current state (i.e., whether it is
   /// still [ThingDiscovery.active]).
-  ThingDiscovery discover({
+  ///
+  /// The shape of the `discover` API is still experimental and will most likely
+  /// change in the future.
+  ThingDiscovery discover(
+    @experimental List<DiscoveryConfiguration> discoveryConfigurations, {
     ThingFilter? thingFilter,
   });
 }


### PR DESCRIPTION
In the context of the recent discussion in the Scripting API repo, I realized that it probably makes more sense to pass the configurations for the `discover` method to the method itself, instead of setting them via the underlying `Servient`.

As there is still an ongoing discussion in the Scripting API taskforce, I labelled the changes as experimental, as there will probably be additional changes (that might lead to a totally different API than the one that is currently in place) as we go along.