### PR TITLE
fix: resolve deprecation warning regarding whereNotNull

### DIFF
--- a/lib/src/core/definitions/security/combo_security_scheme.dart
+++ b/lib/src/core/definitions/security/combo_security_scheme.dart
@@ -4,7 +4,6 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "package:collection/collection.dart";
 import "package:curie/curie.dart";
 
 import "../extensions/json_parser.dart";
@@ -51,7 +50,7 @@ final class ComboSecurityScheme extends SecurityScheme {
     );
 
     final count =
-        [oneOf, allOf].whereNotNull().fold(0, (previous, _) => previous + 1);
+        [oneOf, allOf].nonNulls.fold(0, (previous, _) => previous + 1);
 
     if (count != 1) {
       throw FormatException(


### PR DESCRIPTION
This PR resolves a warning the linter currently raises due to the deprecation of `whereNotNull` from the `collection` package. Getting rid of the warning will once again grant the package a full score on pub.dev.