### PR TITLE
Introduce `startClientFactories` method to Servient

### DIFF
--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -107,13 +107,18 @@ class InternalServient implements Servient {
     return WoT(this);
   }
 
-  @override
-  Future<WoT> start() async {
+  Future<void> _startServers() async {
     final serverStatuses = _servers
         .map((server) => server.start(_serverSecurityCallback))
         .toList(growable: false);
 
     await Future.wait(serverStatuses);
+  }
+
+  @override
+  Future<WoT> start() async {
+    await _startServers();
+
     return startClientFactories();
   }
 

--- a/lib/src/core/implementation/servient.dart
+++ b/lib/src/core/implementation/servient.dart
@@ -52,6 +52,15 @@ abstract class Servient {
   /// discovering Things.
   Future<scripting_api.WoT> start();
 
+  /// Synchronously starts this [Servient] and returns a [scripting_api.WoT]
+  /// runtime object.
+  ///
+  /// In contrast to the [start] method, this method only initializes the
+  /// [ProtocolClientFactory]s and not the [ProtocolServer]s registered with
+  /// this [Servient].
+  /// This has the advantage that it is not necessary to return a [Future].
+  scripting_api.WoT startClientFactories();
+
   /// Adds a new [clientFactory] to this [Servient].
   void addClientFactory(ProtocolClientFactory clientFactory);
 
@@ -90,17 +99,22 @@ class InternalServient implements Servient {
   final ContentSerdes contentSerdes;
 
   @override
+  WoT startClientFactories() {
+    for (final clientFactory in _clientFactories.values) {
+      clientFactory.init();
+    }
+
+    return WoT(this);
+  }
+
+  @override
   Future<WoT> start() async {
     final serverStatuses = _servers
         .map((server) => server.start(_serverSecurityCallback))
         .toList(growable: false);
 
-    for (final clientFactory in _clientFactories.values) {
-      clientFactory.init();
-    }
-
     await Future.wait(serverStatuses);
-    return WoT(this);
+    return startClientFactories();
   }
 
   @override


### PR DESCRIPTION
As it is the case with the `Servient` class in `node-wot`, the `start` method in `dart_wot` is currently marked as `async`. This makes sense in general, as the start methods of the servers registered with the `Servient` are also asynchronous.

However, as the corresponding `init` method of the `ProtocolClientFactories`is _not_ asynchronous (at least in `dart_wot`), it would be possible to start the Servient synchronously and not require the surrounding environment to be `async` as well. Having such a synchronous, partial `start` method can therefore be beneficial for applications that only act as consumers.

To address this use case, this PR introduces a synchronous `startClientFactories` method that basically does what it advertises. It also applies some minor refactoring of the server starting code.

As, as far as I can tell, the `ProtocolClientFactory`s in `node-wot` do not actually perform any actions at the moment in their `init` methods, maybe this is also something that considered for `node-wot` as well. 