### PR TITLE
ci: switch back to latest dart version on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,23 +14,11 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        # TODO: Remove once https://github.com/dart-lang/sdk/issues/55745
-        #       has been resolved
-        sdk: [stable, 3.3.0]
-        exclude:
-          - os: macos-latest
-            sdk: 3.3.0
-          - os: ubuntu-latest
-            sdk: 3.3.0
-          - os: windows-latest
-            sdk: stable
     runs-on: ${{ matrix.os }}
 
     steps:
       - uses: actions/checkout@v3
       - uses: dart-lang/setup-dart@v1
-        with:
-          sdk: ${{ matrix.sdk }}
 
       - name: Install dependencies
         run: dart pub get


### PR DESCRIPTION
Since https://github.com/dart-lang/sdk/issues/55745 apparently has been resolved with the latest Dart SDK release, this PR removes the exception that was made for Windows.