### PR TITLE
style!(thing_description.dart: add a missing period

### DIFF
--- a/lib/src/core/definitions/thing_description.dart
+++ b/lib/src/core/definitions/thing_description.dart
@@ -19,7 +19,7 @@ import "security/security_scheme.dart";
 import "thing_model.dart";
 import "version_info.dart";
 
-/// Represents a WoT Thing Description
+/// Represents a WoT Thing Description.
 @immutable
 class ThingDescription {
   /// Creates a new Thing Description object.


### PR DESCRIPTION
Due to using the wrong format for commit messages indicating breaking changes in #191, the version in #190 did not get bumped correctly. This PR serves as a workaround (that won't be necessary again in the future).