### PR TITLE
feat(binding_http): add possibility to define a custom SecurityContext

### DIFF
--- a/lib/src/binding_http/http_client_factory.dart
+++ b/lib/src/binding_http/http_client_factory.dart
@@ -13,10 +13,14 @@ import "http_config.dart";
 final class HttpClientFactory implements ProtocolClientFactory {
   /// Creates a new [HttpClientFactory] based on an optional [HttpConfig].
   HttpClientFactory({
+    HttpClientConfig? httpClientConfig,
     AsyncClientSecurityCallback<BasicCredentials>? basicCredentialsCallback,
     AsyncClientSecurityCallback<BearerCredentials>? bearerCredentialsCallback,
   })  : _basicCredentialsCallback = basicCredentialsCallback,
-        _bearerCredentialsCallback = bearerCredentialsCallback;
+        _bearerCredentialsCallback = bearerCredentialsCallback,
+        _httpClientConfig = httpClientConfig;
+
+  final HttpClientConfig? _httpClientConfig;
 
   final AsyncClientSecurityCallback<BasicCredentials>?
       _basicCredentialsCallback;
@@ -34,6 +38,7 @@ final class HttpClientFactory implements ProtocolClientFactory {
 
   @override
   ProtocolClient createClient() => HttpClient(
+        httpClientConfig: _httpClientConfig,
         basicCredentialsCallback: _basicCredentialsCallback,
         bearerCredentialsCallback: _bearerCredentialsCallback,
       );

--- a/lib/src/binding_http/http_config.dart
+++ b/lib/src/binding_http/http_config.dart
@@ -4,6 +4,8 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
+import "package:meta/meta.dart";
+
 /// Allows for configuring the behavior of HTTP clients and servers.
 class HttpConfig {
   /// Creates a new [HttpConfig] object.
@@ -16,4 +18,20 @@ class HttpConfig {
 
   /// Indicates if the client or server should use HTTPS.
   bool? secure;
+}
+
+/// Configuration parameters specific to dart_wot's HTTP Client implementation.
+@immutable
+class HttpClientConfig {
+  /// Creates a new [HttpClientConfig] object.
+  const HttpClientConfig({
+    this.trustedCertificates,
+  });
+
+  /// List of trusted certificates that will be added to the security contexts
+  /// of newly created HTTP clients.
+  ///
+  /// Certificates can either use the PEM or or the PKCS12 format, the latter of
+  /// which also supports the use of an optional password.
+  final List<({List<int> certificate, String? password})>? trustedCertificates;
 }


### PR DESCRIPTION
To be able to add additional trusted certificates to an `HttpClient`, this PR adjusts the binding implementation a little to allow for the creation of a custom internal `SecurityContext`, which can be enhanced with certificates that are included in an `HttpClientConfig`.