### PR TITLE
Reactivate `withTrustedRoots` by default in HTTP binding

### DIFF
--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -54,7 +54,9 @@ final class HttpClient extends ProtocolClient
             IOClient(io.HttpClient(context: _createContext(httpClientConfig)));
 
   static SecurityContext _createContext(HttpClientConfig? httpClientConfig) {
-    final context = SecurityContext();
+    final context = SecurityContext(
+      withTrustedRoots: httpClientConfig?.withTrustedRoots ?? true,
+    );
 
     final trustedCertificates = httpClientConfig?.trustedCertificates ?? [];
 

--- a/lib/src/binding_http/http_config.dart
+++ b/lib/src/binding_http/http_config.dart
@@ -25,8 +25,13 @@ class HttpConfig {
 class HttpClientConfig {
   /// Creates a new [HttpClientConfig] object.
   const HttpClientConfig({
+    this.withTrustedRoots = true,
     this.trustedCertificates,
   });
+
+  /// Indicates whether the security contexts created from this config will
+  /// incorporate trusted root certificates from the underlying platform.
+  final bool withTrustedRoots;
 
   /// List of trusted certificates that will be added to the security contexts
   /// of newly created HTTP clients.


### PR DESCRIPTION
While #194 introduced the ability to set custom trusted certificates for the security contexts that are being created from the HTTP binding, it accidentally let the HTTP clients not use the default trusted root certificates of the underlying platform anymore. This PR fixes the issue by introducing a new config parameter, partly by using it in an appropriate place.