### PR TITLE
feat(binding_coap)!: remove support for cov:observe subprotocol

### DIFF
--- a/example/complex_example.dart
+++ b/example/complex_example.dart
@@ -34,7 +34,6 @@ const thingDescriptionJson = {
         {
           "href": "coap://californium.eclipseprojects.io/obs",
           "op": ["observeproperty", "unobserveproperty"],
-          "subprotocol": "cov:observe",
         }
       ],
     },

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -421,22 +421,14 @@ final class CoapClient extends ProtocolClient
       accept: form.accept,
     );
 
-    final subprotocol = form.coapSubprotocol ?? operationType.subprotocol;
-
     final coapClient = coap.CoapClient(
       form.resolvedHref,
       config: _InternalCoapConfig(_coapConfig ?? const CoapConfig()),
     );
 
-    if (subprotocol == CoapSubprotocol.observe) {
-      final observeClientRelation = await coapClient.observe(request);
-      observeClientRelation.listen(handleResponse);
-      return CoapSubscription(coapClient, observeClientRelation, complete);
-    }
-
-    final response = await coapClient.send(request);
-    handleResponse(response);
-    return CoapSubscription(coapClient, null, complete);
+    final observeClientRelation = await coapClient.observe(request);
+    observeClientRelation.listen(handleResponse);
+    return CoapSubscription(coapClient, observeClientRelation, complete);
   }
 
   @override

--- a/lib/src/binding_coap/coap_client_factory.dart
+++ b/lib/src/binding_coap/coap_client_factory.dart
@@ -8,7 +8,6 @@ import "../../core.dart";
 
 import "coap_client.dart";
 import "coap_config.dart";
-import "coap_definitions.dart";
 
 /// A [ProtocolClientFactory] that produces CoAP clients.
 final class CoapClientFactory implements ProtocolClientFactory {
@@ -49,18 +48,6 @@ final class CoapClientFactory implements ProtocolClientFactory {
 
   @override
   bool supportsOperation(OperationType operationType, String? subprotocol) {
-    const observeOperations = [
-      OperationType.observeproperty,
-      OperationType.unobserveproperty,
-      OperationType.subscribeevent,
-      OperationType.unsubscribeevent,
-    ];
-
-    if (observeOperations.contains(operationType)) {
-      return CoapSubprotocol.tryParse(subprotocol ?? "") ==
-          CoapSubprotocol.observe;
-    }
-
     return subprotocol == null;
   }
 }

--- a/lib/src/binding_coap/coap_definitions.dart
+++ b/lib/src/binding_coap/coap_definitions.dart
@@ -50,20 +50,3 @@ enum CoapRequestMethod {
   static CoapRequestMethod? fromString(String stringValue) =>
       _registry[stringValue];
 }
-
-/// Enumeration of available CoAP subprotocols.
-enum CoapSubprotocol {
-  /// Subprotocol for observing CoAP resources.
-  observe,
-  ;
-
-  /// Tries to match the given [subprotocol] string to one of the known
-  /// [CoapSubprotocol.values].
-  static CoapSubprotocol? tryParse(String subprotocol) {
-    if (subprotocol == "cov:observe") {
-      return CoapSubprotocol.observe;
-    }
-
-    return null;
-  }
-}

--- a/lib/src/binding_coap/coap_extensions.dart
+++ b/lib/src/binding_coap/coap_extensions.dart
@@ -36,15 +36,6 @@ extension CoapFormExtension on AugmentedForm {
   bool get usesAutoScheme =>
       securityDefinitions.whereType<AutoSecurityScheme>().isNotEmpty;
 
-  /// Get the [CoapSubprotocol] for this [AugmentedForm], if one is set.
-  CoapSubprotocol? get coapSubprotocol {
-    if (subprotocol == coapPrefixMapping.expandCurieString("observe")) {
-      return CoapSubprotocol.observe;
-    }
-
-    return null;
-  }
-
   /// The Content-Format for CoAP request and response payloads.
   CoapMediaType get contentFormat {
     final formDefinition = _obtainVocabularyTerm<int>("contentFormat");
@@ -136,8 +127,8 @@ extension CoapExpectedResponseExtension on ExpectedResponse {
   }
 }
 
-/// Extension for determining the corresponding [CoapRequestMethod] and
-/// [CoapSubprotocol] for an [OperationType].
+/// Extension for determining the corresponding [CoapRequestMethod] for an
+/// [OperationType].
 extension OperationTypeExtension on OperationType {
   /// Determines the [CoapRequestMethod] for this [OperationType].
   CoapRequestMethod get requestMethod {
@@ -159,22 +150,6 @@ extension OperationTypeExtension on OperationType {
       case OperationType.unsubscribeevent:
         return CoapRequestMethod.get;
     }
-  }
-
-  /// Determines the [CoapSubprotocol] (if any) for this [OperationType].
-  ///
-  /// The only supported subprotocol at the moment is `observe`.
-  CoapSubprotocol? get subprotocol {
-    if ([
-      OperationType.subscribeevent,
-      OperationType.unsubscribeevent,
-      OperationType.observeproperty,
-      OperationType.unobserveproperty,
-    ].contains(this)) {
-      return CoapSubprotocol.observe;
-    }
-
-    return null;
   }
 }
 

--- a/test/binding_coap/coap_client_factory_test.dart
+++ b/test/binding_coap/coap_client_factory_test.dart
@@ -24,12 +24,12 @@ void main() {
 
       final testVector = [
         (
-          expectedResult: true,
+          expectedResult: false,
           operationTypes: observeOperations,
           subprotocol: "cov:observe",
         ),
         (
-          expectedResult: false,
+          expectedResult: true,
           operationTypes: observeOperations,
           subprotocol: null,
         ),

--- a/test/binding_coap/coap_definitions_test.dart
+++ b/test/binding_coap/coap_definitions_test.dart
@@ -88,12 +88,4 @@ void main() {
       );
     });
   });
-
-  test("parse CoAP subprotocols", () async {
-    final observeSubprotocol = CoapSubprotocol.tryParse("cov:observe");
-    expect(observeSubprotocol == CoapSubprotocol.observe, isTrue);
-
-    final unknownSubprotocol = CoapSubprotocol.tryParse("foobar");
-    expect(unknownSubprotocol, isNull);
-  });
 }


### PR DESCRIPTION
Via https://github.com/w3c/wot-binding-templates/pull/353, the `cov:observe` subprotocol has been removed from the CoAP binding template. This PR incorporates these changes by removing the code related to the now outdated subprotocol.

Currently, the polling behavior that is supposed to be used as a fallback as described in the binding template is not really supported yet, but I think this is something that should rather be added to the underlying CoAP library. I will investigate this in future PRs :)