### PR TITLE
Make directory discovery a bit more robust

### DIFF
--- a/example/tdd_discovery.dart
+++ b/example/tdd_discovery.dart
@@ -1,0 +1,30 @@
+// Copyright 2024 Contributors to the Eclipse Foundation. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// SPDX-License-Identifier: BSD-3-Clause
+
+// ignore_for_file: avoid_print
+
+import "package:dart_wot/binding_http.dart";
+import "package:dart_wot/core.dart";
+
+Future<void> main() async {
+  final servient = Servient.create(
+    clientFactories: [
+      HttpClientFactory(),
+    ],
+  );
+  final wot = await servient.start();
+
+  final url = Uri.parse("http://plugfest.thingweb.io:8081");
+  print("Requesting TD from $url ...");
+  final thingDiscoveryProcess = await wot.exploreDirectory(url);
+
+  thingDiscoveryProcess.listen(
+    (thingDescription) => print(thingDescription.title),
+    onError: print,
+  );
+
+  await servient.shutdown();
+}

--- a/lib/src/core/definitions/extensions/json_parser.dart
+++ b/lib/src/core/definitions/extensions/json_parser.dart
@@ -61,7 +61,9 @@ extension ParseField on Map<String, dynamic> {
       return <String, dynamic>{} as T;
     }
 
-    throw FormatException("Expected $T, got ${fieldValue.runtimeType}");
+    throw FormatException(
+      "Expected $T, got ${fieldValue.runtimeType} for field $name",
+    );
   }
 
   /// Parses a single field with a given [name] as a [Uri].

--- a/lib/src/core/implementation/thing_discovery.dart
+++ b/lib/src/core/implementation/thing_discovery.dart
@@ -485,11 +485,11 @@ class ThingDiscoveryProcess extends Stream<ThingDescription>
   }) {
     final streamSubscription = _thingDescriptionStream.listen(
       onData,
-      onError: (error, stackTrace) {
+      onError: (error) {
         if (error is Exception) {
           _error = error;
           // ignore: avoid_dynamic_calls
-          onError?.call(error, stackTrace);
+          onError?.call(error);
         }
       },
       onDone: () {

--- a/test/core/discovery_test.dart
+++ b/test/core/discovery_test.dart
@@ -352,7 +352,7 @@ void main() {
         (event) {
           counter++;
         },
-        onError: (error, stackTrace) async {},
+        onError: (error) async {},
         onDone: () {
           expect(counter, 0);
           expect(thingDiscoveryProcess.done, true);


### PR DESCRIPTION
At the moment, discovery via the `exploreDirectory` method stops completely when an invalid TD is encountered during the discovery process.

This PR changes the logic for deserializing the discovered TDs into `ThingDescription` objects, making the process a bit more reliable, as invalid TDs are just being skipped now.

In order to help with debugging, one of the error message that is emitted during deserialization is also improved a bit and all errors during the directory discovery process will be logged via the developer tools.