### PR TITLE
feat(binding_coap): add support for PEM root certificates

### DIFF
--- a/lib/binding_coap.dart
+++ b/lib/binding_coap.dart
@@ -10,6 +10,9 @@
 /// [spec link]: https://www.w3.org/TR/wot-binding-templates/
 library binding_coap;
 
+export "package:coap/coap.dart"
+    show Certificate, DerCertificate, PemCertificate;
+
 export "src/binding_coap/coap_client_factory.dart";
 export "src/binding_coap/coap_config.dart";
 export "src/binding_coap/coap_server.dart";

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 import "dart:async";
-import "dart:typed_data";
 
 import "package:coap/coap.dart" as coap;
 import "package:coap/config/coap_config_default.dart";
@@ -41,7 +40,7 @@ class _InternalCoapConfig extends CoapConfigDefault {
   final bool dtlsWithTrustedRoots;
 
   @override
-  final List<Uint8List> rootCertificates;
+  final List<coap.Certificate> rootCertificates;
 }
 
 coap.PskCredentialsCallback? _createPskCallback(

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -25,7 +25,8 @@ class _InternalCoapConfig extends CoapConfigDefault {
         dtlsCiphers = coapConfig.dtlsCiphers,
         dtlsVerify = coapConfig.dtlsVerify,
         dtlsWithTrustedRoots = coapConfig.dtlsWithTrustedRoots,
-        rootCertificates = coapConfig.rootCertificates;
+        rootCertificates = coapConfig.rootCertificates,
+        openSslSecurityLevel = coapConfig.openSslSecurityLevel;
 
   @override
   final int preferredBlockSize;
@@ -41,6 +42,9 @@ class _InternalCoapConfig extends CoapConfigDefault {
 
   @override
   final List<coap.Certificate> rootCertificates;
+
+  @override
+  final int? openSslSecurityLevel;
 }
 
 coap.PskCredentialsCallback? _createPskCallback(

--- a/lib/src/binding_coap/coap_config.dart
+++ b/lib/src/binding_coap/coap_config.dart
@@ -21,6 +21,7 @@ class CoapConfig {
     this.rootCertificates = const [],
     this.dtlsWithTrustedRoots = true,
     this.dtlsVerify = true,
+    this.openSslSecurityLevel,
   });
 
   /// Whether certificates should be verified by OpenSSL.
@@ -56,4 +57,19 @@ class CoapConfig {
   ///
   /// Defaults to 60 seconds.
   final Duration multicastDiscoveryTimeout;
+
+  /// Security level override for using DTLS with OpenSSL.
+  ///
+  /// The possible values for the security level range from 0 to 5.
+  ///
+  /// Lowering the security level can be necessary with newer versions of
+  /// OpenSSL to still be able to use the mandatory CoAP cipher suites
+  /// (e.g., `TLS_PSK_WITH_AES_128_CCM_8`, see [section 9.1.3.1 of RFC 7252]).
+  ///
+  /// See the [OpenSSL documentation] for more information on the meaning of the
+  /// individual security levels.
+  ///
+  /// [section 9.1.3.1 of RFC 7252]: https://datatracker.ietf.org/doc/html/rfc7252#section-9.1.3.1
+  /// [OpenSSL documentation]: https://docs.openssl.org/master/man3/SSL_CTX_set_security_level/#default-callback-behaviour
+  final int? openSslSecurityLevel;
 }

--- a/lib/src/binding_coap/coap_config.dart
+++ b/lib/src/binding_coap/coap_config.dart
@@ -4,8 +4,7 @@
 //
 // SPDX-License-Identifier: BSD-3-Clause
 
-import "dart:typed_data";
-
+import "package:coap/coap.dart";
 import "package:meta/meta.dart";
 
 /// Allows for configuring the behavior of CoAP clients and servers.
@@ -34,7 +33,7 @@ class CoapConfig {
   final String? dtlsCiphers;
 
   /// List of custom root certificates to use with OpenSSL.
-  final List<Uint8List> rootCertificates;
+  final List<Certificate> rootCertificates;
 
   /// The port number used by a client or server. Defaults to 5683.
   final int port;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ dev_dependencies:
 
 dependencies:
   cbor: ^6.1.0
-  coap: ^9.0.0
+  coap: ^9.1.0
   collection: ^1.17.2
   curie: ^0.1.0
   dcaf: ^0.1.0


### PR DESCRIPTION
This PR adds some improvements to the handling of DTLS within the CoAP binding. To be able to merge this PR, a new version of the `coap` package has to be released first, therefore I am keeping this one a draft for now.