### PR TITLE
Required named parameters should be before optional named parameters.

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,3 +26,4 @@ linter:
     close_sinks: true
     cascade_invocations: true
     only_throw_errors: true
+    always_put_required_named_parameters_first: true

--- a/lib/src/binding_coap/coap_client.dart
+++ b/lib/src/binding_coap/coap_client.dart
@@ -148,8 +148,8 @@ final class CoapClient extends ProtocolClient
   Future<Content> _sendRequest(
     Uri uri,
     coap.RequestMethod method, {
-    Content? content,
     required AugmentedForm? form,
+    Content? content,
     coap.CoapMediaType? format,
     coap.CoapMediaType? accept,
     coap.BlockSize? block1Size,
@@ -204,8 +204,8 @@ final class CoapClient extends ProtocolClient
   Future<DiscoveryContent> _sendDiscoveryRequest(
     Uri uri,
     coap.RequestMethod method, {
-    Content? content,
     required AugmentedForm? form,
+    Content? content,
     coap.CoapMediaType? format,
     coap.CoapMediaType? accept,
     coap.BlockSize? block1Size,
@@ -388,8 +388,8 @@ final class CoapClient extends ProtocolClient
   Future<Subscription> subscribeResource(
     AugmentedForm form, {
     required void Function(Content content) next,
-    void Function(Exception error)? error,
     required void Function() complete,
+    void Function(Exception error)? error,
   }) async {
     final OperationType operationType = form.op.firstWhere(
       (element) => [OperationType.subscribeevent, OperationType.observeproperty]

--- a/lib/src/binding_http/http_client.dart
+++ b/lib/src/binding_http/http_client.dart
@@ -309,8 +309,8 @@ final class HttpClient extends ProtocolClient
   Future<Subscription> subscribeResource(
     AugmentedForm form, {
     required void Function(Content content) next,
-    void Function(Exception error)? error,
     required void Function() complete,
+    void Function(Exception error)? error,
   }) async {
     if (form.subprotocol != "sse") {
       throw const DartWotException(

--- a/lib/src/binding_mqtt/mqtt_client.dart
+++ b/lib/src/binding_mqtt/mqtt_client.dart
@@ -182,8 +182,8 @@ final class MqttClient extends ProtocolClient with MqttDiscoverer {
   Future<Subscription> subscribeResource(
     AugmentedForm form, {
     required void Function(Content content) next,
-    void Function(Exception error)? error,
     required void Function() complete,
+    void Function(Exception error)? error,
   }) async {
     final client = await _connectWithForm(form);
     final topic = form.topicFilter;

--- a/lib/src/core/definitions/interaction_affordances/event.dart
+++ b/lib/src/core/definitions/interaction_affordances/event.dart
@@ -10,12 +10,12 @@ part of "interaction_affordance.dart";
 class Event extends InteractionAffordance {
   /// Creates a new [Event] from a [List] of [forms].
   const Event({
+    required super.forms,
     super.title,
     super.titles,
     super.description,
     super.descriptions,
     super.uriVariables,
-    required super.forms,
     this.subscription,
     this.data,
     this.cancellation,

--- a/lib/src/core/definitions/interaction_affordances/interaction_affordance.dart
+++ b/lib/src/core/definitions/interaction_affordances/interaction_affordance.dart
@@ -26,13 +26,13 @@ part "property.dart";
 sealed class InteractionAffordance implements Serializable {
   /// Creates a new [InteractionAffordance]. Accepts a [List] of [forms].
   const InteractionAffordance({
+    required this.forms,
     this.atType,
     this.title,
     this.titles,
     this.description,
     this.descriptions,
     this.uriVariables,
-    required this.forms,
     this.additionalFields = const {},
   });
 

--- a/lib/src/core/definitions/interaction_affordances/property.dart
+++ b/lib/src/core/definitions/interaction_affordances/property.dart
@@ -12,9 +12,9 @@ class Property extends InteractionAffordance implements DataSchema {
   /// Default constructor that creates a [Property] from a [List] of [forms].
   const Property({
     required super.forms,
+    required this.dataSchema,
     super.uriVariables,
     super.additionalFields,
-    required this.dataSchema,
     this.observable = _defaultObservableValue,
   });
 

--- a/lib/src/core/protocol_interfaces/protocol_client.dart
+++ b/lib/src/core/protocol_interfaces/protocol_client.dart
@@ -31,7 +31,7 @@ abstract base class ProtocolClient {
   Future<Subscription> subscribeResource(
     AugmentedForm form, {
     required void Function(Content content) next,
-    void Function(Exception error)? error,
     required void Function() complete,
+    void Function(Exception error)? error,
   });
 }

--- a/test/core/discovery_test.dart
+++ b/test/core/discovery_test.dart
@@ -211,8 +211,8 @@ final class _MockedProtocolClient extends ProtocolClient with DirectDiscoverer {
   Future<Subscription> subscribeResource(
     Form form, {
     required void Function(Content content) next,
-    void Function(Exception error)? error,
     required void Function() complete,
+    void Function(Exception error)? error,
   }) {
     // TODO: implement subscribeResource
     throw UnimplementedError();


### PR DESCRIPTION
Added [a new lint](https://dart.dev/tools/diagnostic-messages#always_put_required_named_parameters_first) and cleaned up the violations.