### PR TITLE
Remove unnecessary library names

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -26,3 +26,4 @@ linter:
     close_sinks: true
     cascade_invocations: true
     only_throw_errors: true
+    unnecessary_library_name: true

--- a/lib/binding_coap.dart
+++ b/lib/binding_coap.dart
@@ -8,7 +8,7 @@
 /// the [WoT Binding Templates Specification][spec link] for CoAP.
 ///
 /// [spec link]: https://www.w3.org/TR/wot-binding-templates/
-library binding_coap;
+library;
 
 export "package:coap/coap.dart"
     show Certificate, DerCertificate, PemCertificate;

--- a/lib/binding_http.dart
+++ b/lib/binding_http.dart
@@ -8,7 +8,7 @@
 /// the [WoT Binding Templates Specification][spec link] for HTTP.
 ///
 /// [spec link]: https://www.w3.org/TR/wot-binding-templates/
-library binding_http;
+library;
 
 export "src/binding_http/http_client_factory.dart";
 export "src/binding_http/http_config.dart";

--- a/lib/binding_mqtt.dart
+++ b/lib/binding_mqtt.dart
@@ -8,7 +8,7 @@
 /// the latest [WoT Binding Templates Specification][spec link] for MQTT.
 ///
 /// [spec link]: https://w3c.github.io/wot-binding-templates/bindings/protocols/mqtt
-library binding_mqtt;
+library;
 
 export "src/binding_mqtt/mqtt_client_factory.dart";
 export "src/binding_mqtt/mqtt_config.dart";

--- a/lib/core.dart
+++ b/lib/core.dart
@@ -7,7 +7,7 @@
 /// Core implementation providing Scripting API implementations, interfaces
 /// for protocol bindings, and the `Servient` class which provides the WoT
 /// runtime used for consuming, exposing, and discovering Things.
-library core;
+library;
 
 // TODO(JKRhb): Reorganize top-level core package into smaller packages.
 export "src/core/definitions.dart";

--- a/lib/src/core/definitions.dart
+++ b/lib/src/core/definitions.dart
@@ -9,7 +9,7 @@
 /// models for passing credentials to the Scripting API implementation.
 ///
 /// [spec link]: https://www.w3.org/TR/wot-thing-description11/
-library definitions;
+library;
 
 export "package:dcaf/dcaf.dart" show AuthServerRequestCreationHint;
 

--- a/lib/src/core/definitions/interaction_affordances/interaction_affordance.dart
+++ b/lib/src/core/definitions/interaction_affordances/interaction_affordance.dart
@@ -6,7 +6,7 @@
 
 /// Sub-library for defining the three kinds of interaction affordances
 /// (properties, actions, events).
-library interaction_affordance;
+library;
 
 import "package:curie/curie.dart";
 import "package:meta/meta.dart";

--- a/lib/src/core/extensions.dart
+++ b/lib/src/core/extensions.dart
@@ -5,6 +5,6 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /// Sub-library for extensions used by `dart_wot`.
-library extensions;
+library;
 
 export "extensions/uri_extensions.dart";

--- a/lib/src/core/implementation.dart
+++ b/lib/src/core/implementation.dart
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 /// Sub-library containing the actual implementation of the WoT Scripting API.
-library implementation;
+library;
 
 export "implementation/augmented_form.dart";
 export "implementation/codecs/content_codec.dart";

--- a/lib/src/core/scripting_api.dart
+++ b/lib/src/core/scripting_api.dart
@@ -8,7 +8,7 @@
 /// [WoT Scripting API Specification][spec link].
 ///
 /// [spec link]: https://www.w3.org/TR/wot-scripting-api/
-library scripting_api;
+library;
 
 export "scripting_api/consumed_thing.dart";
 export "scripting_api/data_schema_value.dart";


### PR DESCRIPTION
As of Dart 3.4 the official recommendation is to no longer use library names as outlined in this lint documentation: https://dart.dev/tools/linter-rules/unnecessary_library_name

This PR enables that lint and makes the necesarry adjustments.